### PR TITLE
Changes OSX build script to use `brew --prefix` to locate Homebrew

### DIFF
--- a/apps/build.osx.sh
+++ b/apps/build.osx.sh
@@ -1,8 +1,11 @@
 mkdir -p bin
 
+brew_prefix=`brew --prefix`
+brew_prefix=${brew_prefix:-"/Users/fabio/homebrew"}
+
 cc="clang"
-cflags="-I/Users/fabio/homebrew/include/ -Ofast -ffast-math -funroll-loops -march=native -fdiagnostics-color=always -Wall -Wpedantic"
-linkflags="-L/Users/fabio/homebrew/lib -lglfw3 -framework Cocoa -framework OpenGL -framework IOKit -framework CoreVideo"
+cflags="-I$brew_prefix/include/ -Ofast -ffast-math -funroll-loops -march=native -fdiagnostics-color=always -Wall -Wpedantic"
+linkflags="-L$brew_prefix/lib -lglfw3 -framework Cocoa -framework OpenGL -framework IOKit -framework CoreVideo"
 
 cp apps/render_tests.sh bin/
 


### PR DESCRIPTION
I maintained the original path as a fallback, if `brew` wasn't found in your PATH. Probably makes sense to use a more common path for the fallback, but I wanted to get feedback before I changed it.