### PR TITLE
Write binary when saving binfile

### DIFF
--- a/yocto/yocto_gltf.cpp
+++ b/yocto/yocto_gltf.cpp
@@ -2212,7 +2212,7 @@ static inline void _save_textfile(
 //
 static inline bool _save_binfile(const std::string& filename,
     const std::vector<unsigned char>& bin, std::string& errmsg) {
-    auto f = fopen(filename.c_str(), "wt");
+    auto f = fopen(filename.c_str(), "wb");
     if (!f) {
         errmsg = "cannot write file " + filename;
         return false;


### PR DESCRIPTION
Hi, I started testing the library out for writing gltfs and turns out there is a bug in writing the binfiles. I had to check the contents of the file to realize it was using text-mode to write the data from JSON to the sidecar bin files.