### PR TITLE
In yocto_gltf.cpp, a win32 region was still using old code it seems.

### DIFF
--- a/yocto/yocto_gltf.cpp
+++ b/yocto/yocto_gltf.cpp
@@ -3152,9 +3152,9 @@ YGLTF_API fl_gltf* flatten_gltf(const glTF_t* gltf, int scene_idx) {
 // BUG: initialization
 #ifdef _WIN32
                 auto fm = new fl_mesh();
-                fm->name = gltf->meshes.at(mesh_name).name;
+                fm->name = gltf->meshes.at(node->mesh).name;
                 fm->xform = xf;
-                fm->primitives = meshes.at(mesh_name);
+                fm->primitives = meshes.at(node->mesh);
                 fl_gltf->meshes.push_back(fm);
 #else
                 fl_gltf->meshes.push_back(


### PR DESCRIPTION
I've corrected to whatever is used after the #else