### PR TITLE
yocto_img: unique_ptr is defined in <memory>.

### DIFF
--- a/yocto/yocto_img.cpp
+++ b/yocto/yocto_img.cpp
@@ -30,6 +30,7 @@
 
 #include <cmath>
 #include <map>
+#include <memory>
 
 #ifndef _WIN32
 #pragma GCC diagnostic push


### PR DESCRIPTION
Fixes build with gcc 7.1.1.