### PR TITLE
Fixing issue with GLB_CHUNK_LENGTH_UNALIGNED on glb export.

### DIFF
--- a/yocto/yocto_gltf.cpp
+++ b/yocto/yocto_gltf.cpp
@@ -2220,9 +2220,8 @@ bool save_binary_gltf(const std::string& filename, const glTF* gltf,
 
     // fix string
     auto js_str = js.dump(2);
-    if (js_str.length() % 4) {
-        auto count = js_str.length() % 4;
-        for (auto c = 0; c < count; c++) js_str += " ";
+    while (js_str.length() % 4) {
+        js_str += " ";
     }
     uint32_t json_length = (uint32_t)js_str.size();
 


### PR DESCRIPTION
There was an issue with output on the binary gltf format when the length of the JSON block was aligned to 4-byte chunks.