### PR TITLE
fix build on Ubuntu 17.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ else(YOCTO_OPENGL)
 endif(YOCTO_OPENGL)
 
 if(UNIX AND NOT APPLE)
+    set(CMAKE_CXX_FLAGS "-fpermissive -std=c++0x")
     find_package(Threads REQUIRED)
     target_link_libraries(yocto_gl Threads::Threads)
 endif(UNIX AND NOT APPLE)

--- a/yocto/yocto_gl.cpp
+++ b/yocto/yocto_gl.cpp
@@ -8345,7 +8345,7 @@ inline const vector<pair<string, test_light_type>>& test_light_names() {
 
 tuple<vector<instance*>, environment*> add_test_lights(
     scene* scn, test_light_type type) {
-    if (type == test_light_type::none) return {{}, nullptr};
+    if (type == test_light_type::none) return {vector<instance*>(), nullptr};
     switch (type) {
         case test_light_type::pointlight: {
             return {{add_test_instance(scn, test_shape_type::plight,
@@ -8378,7 +8378,7 @@ tuple<vector<instance*>, environment*> add_test_lights(
         } break;
         case test_light_type::envlight: {
             return {
-                {}, add_test_environment(scn, test_environment_type::sky1,
+                vector<instance*>(), add_test_environment(scn, test_environment_type::sky1,
                         lookat_frame3f({0, 1, 0}, {0, 1, 1}, {0, 1, 0}, true))};
         } break;
         default: throw runtime_error("bad value");


### PR DESCRIPTION
The last version of GCC does not build with Braces inside other Braces.
GCC does not build with a variable named as the type at "/yocto-gl/apps/yitrace.cpp:62:18" for this reason I used -fpermissive flags.
