### PR TITLE
Fix for make_window() returning nullptr when using GLEW 

### DIFF
--- a/yocto/yocto_gl.cpp
+++ b/yocto/yocto_gl.cpp
@@ -9918,7 +9918,7 @@ gl_window* make_window(
 
 // init gl extensions
 #ifndef __APPLE__
-    if (!glewInit()) return nullptr;
+    if (glewInit() != GLEW_OK) return nullptr;
 #endif
     return win;
 }


### PR DESCRIPTION
On my system (Arch Linux) make_window() always returned nullptr, which later caused a SIGSEGV address boundary error on the first call to glGenVertexArrays.
 
After a lot of debugging, the problematic line turned out to be
if (!glewInit()) return nullptr;
In fact, glewInit() returns 0 if it executes successfully, as seen in the error codes of the glew library

Changing that line to:
if (glewInit() != GLEW_OK) return nullptr;
fixes the problem.

EDIT: closed last pull request as it used the wrong branch. Reopened this one with the correct one.