### PR TITLE
Json lib compilation issue on MSVC 2017

### DIFF
--- a/yocto/ext/json.hpp
+++ b/yocto/ext/json.hpp
@@ -1380,11 +1380,11 @@ struct from_json_fn
 template<typename T>
 struct static_const
 {
-    static constexpr T value{};
+    static constexpr T value;
 };
 
 template<typename T>
-constexpr T static_const<T>::value;
+constexpr T static_const<T>::value = {};
 
 ////////////////////
 // input adapters //
@@ -9459,7 +9459,7 @@ class basic_json
 
     @since version 1.0.0
     */
-    constexpr operator value_t() const noexcept
+    operator value_t() const noexcept
     {
         return m_type;
     }


### PR DESCRIPTION
The compilation issue is still present on json lib v3.0, so I propose again the fix.