### PR TITLE
Fix JSON issue on MSVC 2017

### DIFF
--- a/yocto/yocto_gl.cpp
+++ b/yocto/yocto_gl.cpp
@@ -3139,7 +3139,7 @@ inline void serialize_from_json(bool& val, const json& js) {
 // Parse std::string function.
 inline void serialize_from_json(string& val, const json& js) {
     if (!js.is_string()) throw runtime_error("string expected");
-    val = js;
+    val = js.get<std::string>();
 }
 
 // Parse json function.


### PR DESCRIPTION
On MSVC 2017 the implicit cast to string doesn't work due a C++ issue, so I fix it following the JSON library usage.
Reference:
https://github.com/nlohmann/json#basic-usage
https://github.com/nlohmann/json/issues/861