### PR TITLE
Fix division by zero

### DIFF
--- a/yocto/yocto_gl.h
+++ b/yocto/yocto_gl.h
@@ -3418,7 +3418,7 @@ inline void rng_shuffle(rng_pcg32& rng, T* vals, int num) {
     // Draw uniformly distributed permutation and permute the
     // given STL container
     for (auto i = num - 1; i > 0; --i)
-        swap(vals[i], vals[next_rand1i(rng, (uint32_t)(i - 1))]);
+        swap(vals[i], vals[next_rand1i(rng, (uint32_t)i)]);
 }
 
 /// Random shuffle of a sequence.


### PR DESCRIPTION
The index 'i' already start from 'num-1', so is wrong subtract one to 'i' in the cycle, because this cause a division by zero in 'next_rand1i'.