### PR TITLE
Fixes issues with compilation on Ubuntu 18.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ add_library(ygl
 
 if(UNIX AND NOT APPLE)
     find_package(Threads REQUIRED)
-    target_link_libraries(ygl Threads::Threads)
+    target_link_libraries(ygl Threads::Threads X11 dl)
 endif(UNIX AND NOT APPLE)
 
 add_executable(ytrace apps/ytrace.cpp)


### PR DESCRIPTION
Compilation on Ubuntu fails with

```
/usr/bin/x86_64-linux-gnu-ld: /usr/local/lib/libglfw3.a(x11_window.c.o): undefined reference to symbol 'XConvertSelection'
```

And once X11 is added, with

```
/usr/bin/x86_64-linux-gnu-ld: /usr/local/lib/libglfw3.a(vulkan.c.o): undefined reference to symbol 'dlclose@@GLIBC_2.2.5'
```

This adds the libraries to Unix target. Shouldn't have any negative effect on normal build if dynamic libraries are used.