### PR TITLE
Using std:: objects directly

### DIFF
--- a/apps/yglutils.cpp
+++ b/apps/yglutils.cpp
@@ -83,7 +83,7 @@ uint make_glprogram(const char* vertex, const char* fragment) {
     glGetShaderiv(vid, GL_COMPILE_STATUS, &errflags);
     if (!errflags) {
         glGetShaderInfoLog(vid, 10000, 0, errbuf);
-        throw std::runtime_error(
+        throw runtime_error(
             string("shader not compiled\n\n") + errbuf);
     }
     assert(glGetError() == GL_NO_ERROR);
@@ -96,7 +96,7 @@ uint make_glprogram(const char* vertex, const char* fragment) {
     glGetShaderiv(fid, GL_COMPILE_STATUS, &errflags);
     if (!errflags) {
         glGetShaderInfoLog(fid, 10000, 0, errbuf);
-        throw std::runtime_error(
+        throw runtime_error(
             string("shader not compiled\n\n") + errbuf);
     }
     assert(glGetError() == GL_NO_ERROR);
@@ -111,12 +111,12 @@ uint make_glprogram(const char* vertex, const char* fragment) {
     glGetProgramiv(pid, GL_LINK_STATUS, &errflags);
     if (!errflags) {
         glGetProgramInfoLog(pid, 10000, 0, errbuf);
-        throw std::runtime_error(string("program not linked\n\n") + errbuf);
+        throw runtime_error(string("program not linked\n\n") + errbuf);
     }
     glGetProgramiv(pid, GL_VALIDATE_STATUS, &errflags);
     if (!errflags) {
         glGetProgramInfoLog(pid, 10000, 0, errbuf);
-        throw std::runtime_error(string("program not linked\n\n") + errbuf);
+        throw runtime_error(string("program not linked\n\n") + errbuf);
     }
     assert(glGetError() == GL_NO_ERROR);
 
@@ -484,7 +484,7 @@ void draw_glimage(
 glwindow* make_glwindow(const vec2i& size, const char* title,
     void* user_pointer, void (*refresh)(GLFWwindow*)) {
     // init glfw
-    if (!glfwInit()) throw std::runtime_error("cannot open glwindow");
+    if (!glfwInit()) throw runtime_error("cannot open glwindow");
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
     glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
     glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
@@ -502,7 +502,7 @@ glwindow* make_glwindow(const vec2i& size, const char* title,
     glfwSetWindowUserPointer(win, user_pointer);
 
     // init gl extensions
-    if (!gladLoadGL()) throw std::runtime_error("cannot initialize glad");
+    if (!gladLoadGL()) throw runtime_error("cannot initialize glad");
 
     return win;
 }

--- a/apps/yglutils.cpp
+++ b/apps/yglutils.cpp
@@ -84,7 +84,7 @@ uint make_glprogram(const char* vertex, const char* fragment) {
     if (!errflags) {
         glGetShaderInfoLog(vid, 10000, 0, errbuf);
         throw std::runtime_error(
-            std::string("shader not compiled\n\n") + errbuf);
+            string("shader not compiled\n\n") + errbuf);
     }
     assert(glGetError() == GL_NO_ERROR);
 
@@ -97,7 +97,7 @@ uint make_glprogram(const char* vertex, const char* fragment) {
     if (!errflags) {
         glGetShaderInfoLog(fid, 10000, 0, errbuf);
         throw std::runtime_error(
-            std::string("shader not compiled\n\n") + errbuf);
+            string("shader not compiled\n\n") + errbuf);
     }
     assert(glGetError() == GL_NO_ERROR);
 
@@ -111,12 +111,12 @@ uint make_glprogram(const char* vertex, const char* fragment) {
     glGetProgramiv(pid, GL_LINK_STATUS, &errflags);
     if (!errflags) {
         glGetProgramInfoLog(pid, 10000, 0, errbuf);
-        throw std::runtime_error(std::string("program not linked\n\n") + errbuf);
+        throw std::runtime_error(string("program not linked\n\n") + errbuf);
     }
     glGetProgramiv(pid, GL_VALIDATE_STATUS, &errflags);
     if (!errflags) {
         glGetProgramInfoLog(pid, 10000, 0, errbuf);
-        throw std::runtime_error(std::string("program not linked\n\n") + errbuf);
+        throw std::runtime_error(string("program not linked\n\n") + errbuf);
     }
     assert(glGetError() == GL_NO_ERROR);
 
@@ -224,7 +224,7 @@ void update_gltexture(
 }
 
 template <typename T>
-uint make_glarraybuffer_impl(const std::vector<T>& buf, bool dynamic) {
+uint make_glarraybuffer_impl(const vector<T>& buf, bool dynamic) {
     auto bid = (uint)0;
     assert(glGetError() == GL_NO_ERROR);
     glGenBuffers(1, &bid);
@@ -235,21 +235,21 @@ uint make_glarraybuffer_impl(const std::vector<T>& buf, bool dynamic) {
     return bid;
 }
 
-uint make_glarraybuffer(const std::vector<float>& buf, bool dynamic) {
+uint make_glarraybuffer(const vector<float>& buf, bool dynamic) {
     return make_glarraybuffer_impl(buf, dynamic);
 }
-uint make_glarraybuffer(const std::vector<vec2f>& buf, bool dynamic) {
+uint make_glarraybuffer(const vector<vec2f>& buf, bool dynamic) {
     return make_glarraybuffer_impl(buf, dynamic);
 }
-uint make_glarraybuffer(const std::vector<vec3f>& buf, bool dynamic) {
+uint make_glarraybuffer(const vector<vec3f>& buf, bool dynamic) {
     return make_glarraybuffer_impl(buf, dynamic);
 }
-uint make_glarraybuffer(const std::vector<vec4f>& buf, bool dynamic) {
+uint make_glarraybuffer(const vector<vec4f>& buf, bool dynamic) {
     return make_glarraybuffer_impl(buf, dynamic);
 }
 
 template <typename T>
-uint make_glelementbuffer_impl(const std::vector<T>& buf, bool dynamic) {
+uint make_glelementbuffer_impl(const vector<T>& buf, bool dynamic) {
     auto bid = (uint)0;
     assert(glGetError() == GL_NO_ERROR);
     glGenBuffers(1, &bid);
@@ -260,13 +260,13 @@ uint make_glelementbuffer_impl(const std::vector<T>& buf, bool dynamic) {
     return bid;
 }
 
-uint make_glelementbuffer(const std::vector<int>& buf, bool dynamic) {
+uint make_glelementbuffer(const vector<int>& buf, bool dynamic) {
     return make_glelementbuffer_impl(buf, dynamic);
 }
-uint make_glelementbuffer(const std::vector<vec2i>& buf, bool dynamic) {
+uint make_glelementbuffer(const vector<vec2i>& buf, bool dynamic) {
     return make_glelementbuffer_impl(buf, dynamic);
 }
-uint make_glelementbuffer(const std::vector<vec3i>& buf, bool dynamic) {
+uint make_glelementbuffer(const vector<vec3i>& buf, bool dynamic) {
     return make_glelementbuffer_impl(buf, dynamic);
 }
 
@@ -464,9 +464,9 @@ void draw_glimage(
         )";
         gl_prog     = make_glprogram(vert, frag);
         gl_texcoord = make_glarraybuffer(
-            std::vector<vec2f>{{0, 0}, {0, 1}, {1, 1}, {1, 0}}, false);
+            vector<vec2f>{{0, 0}, {0, 1}, {1, 1}, {1, 0}}, false);
         gl_triangles = make_glelementbuffer(
-            std::vector<vec3i>{{0, 1, 2}, {0, 2, 3}}, false);
+            vector<vec3i>{{0, 1, 2}, {0, 2, 3}}, false);
     }
 
     // draw
@@ -618,7 +618,7 @@ bool draw_button_glwidget(glwindow* win, const char* lbl) {
 }
 
 void draw_label_glwidgets(
-    glwindow* win, const char* lbl, const std::string& txt) {
+    glwindow* win, const char* lbl, const string& txt) {
     ImGui::LabelText(lbl, "%s", txt.c_str());
 }
 
@@ -633,7 +633,7 @@ void draw_separator_glwidget(glwindow* win) { ImGui::Separator(); }
 
 void continue_glwidgets_line(glwindow* win) { ImGui::SameLine(); }
 
-bool draw_textinput_glwidget(glwindow* win, const char* lbl, std::string& val) {
+bool draw_textinput_glwidget(glwindow* win, const char* lbl, string& val) {
     char buf[4096];
     auto num = 0;
     for (auto c : val) buf[num++] = c;
@@ -749,7 +749,7 @@ void begin_selectabletreeleaf_glwidget(
 }
 
 bool draw_combobox_glwidget(glwindow* win, const char* lbl, int& val,
-    const std::vector<std::string>& labels) {
+    const vector<string>& labels) {
     if (!ImGui::BeginCombo(lbl, labels[val].c_str())) return false;
     auto old_val = val;
     for (auto i = 0; i < labels.size(); i++) {
@@ -762,8 +762,8 @@ bool draw_combobox_glwidget(glwindow* win, const char* lbl, int& val,
     return val != old_val;
 }
 
-bool draw_combobox_glwidget(glwindow* win, const char* lbl, std::string& val,
-    const std::vector<std::string>& labels) {
+bool draw_combobox_glwidget(glwindow* win, const char* lbl, string& val,
+    const vector<string>& labels) {
     if (!ImGui::BeginCombo(lbl, val.c_str())) return false;
     auto old_val = val;
     for (auto i = 0; i < labels.size(); i++) {
@@ -778,7 +778,7 @@ bool draw_combobox_glwidget(glwindow* win, const char* lbl, std::string& val,
 }
 
 bool draw_combobox_glwidget(glwindow* win, const char* lbl, int& idx,
-    const std::vector<void*>& vals, const char* (*label)(void*)) {
+    const vector<void*>& vals, const char* (*label)(void*)) {
     if (!ImGui::BeginCombo(lbl, label(vals.at(idx)))) return false;
     auto old_idx = idx;
     for (auto i = 0; i < vals.size(); i++) {
@@ -792,7 +792,7 @@ bool draw_combobox_glwidget(glwindow* win, const char* lbl, int& idx,
 }
 
 bool draw_combobox_glwidget(glwindow* win, const char* lbl, void*& val,
-    const std::vector<void*>& vals, const char* (*label)(void*),
+    const vector<void*>& vals, const char* (*label)(void*),
     bool                      include_null) {
     if (!ImGui::BeginCombo(lbl, (val) ? label(val) : "<none>")) return false;
     auto old_val = val;

--- a/apps/yglutils.cpp
+++ b/apps/yglutils.cpp
@@ -83,8 +83,7 @@ uint make_glprogram(const char* vertex, const char* fragment) {
     glGetShaderiv(vid, GL_COMPILE_STATUS, &errflags);
     if (!errflags) {
         glGetShaderInfoLog(vid, 10000, 0, errbuf);
-        throw runtime_error(
-            string("shader not compiled\n\n") + errbuf);
+        throw runtime_error(string("shader not compiled\n\n") + errbuf);
     }
     assert(glGetError() == GL_NO_ERROR);
 
@@ -96,8 +95,7 @@ uint make_glprogram(const char* vertex, const char* fragment) {
     glGetShaderiv(fid, GL_COMPILE_STATUS, &errflags);
     if (!errflags) {
         glGetShaderInfoLog(fid, 10000, 0, errbuf);
-        throw runtime_error(
-            string("shader not compiled\n\n") + errbuf);
+        throw runtime_error(string("shader not compiled\n\n") + errbuf);
     }
     assert(glGetError() == GL_NO_ERROR);
 
@@ -617,8 +615,7 @@ bool draw_button_glwidget(glwindow* win, const char* lbl) {
     return ImGui::Button(lbl);
 }
 
-void draw_label_glwidgets(
-    glwindow* win, const char* lbl, const string& txt) {
+void draw_label_glwidgets(glwindow* win, const char* lbl, const string& txt) {
     ImGui::LabelText(lbl, "%s", txt.c_str());
 }
 
@@ -748,8 +745,8 @@ void begin_selectabletreeleaf_glwidget(
     if (ImGui::IsItemClicked()) selection = content;
 }
 
-bool draw_combobox_glwidget(glwindow* win, const char* lbl, int& val,
-    const vector<string>& labels) {
+bool draw_combobox_glwidget(
+    glwindow* win, const char* lbl, int& val, const vector<string>& labels) {
     if (!ImGui::BeginCombo(lbl, labels[val].c_str())) return false;
     auto old_val = val;
     for (auto i = 0; i < labels.size(); i++) {
@@ -762,8 +759,8 @@ bool draw_combobox_glwidget(glwindow* win, const char* lbl, int& val,
     return val != old_val;
 }
 
-bool draw_combobox_glwidget(glwindow* win, const char* lbl, string& val,
-    const vector<string>& labels) {
+bool draw_combobox_glwidget(
+    glwindow* win, const char* lbl, string& val, const vector<string>& labels) {
     if (!ImGui::BeginCombo(lbl, val.c_str())) return false;
     auto old_val = val;
     for (auto i = 0; i < labels.size(); i++) {
@@ -792,8 +789,7 @@ bool draw_combobox_glwidget(glwindow* win, const char* lbl, int& idx,
 }
 
 bool draw_combobox_glwidget(glwindow* win, const char* lbl, void*& val,
-    const vector<void*>& vals, const char* (*label)(void*),
-    bool                      include_null) {
+    const vector<void*>& vals, const char* (*label)(void*), bool include_null) {
     if (!ImGui::BeginCombo(lbl, (val) ? label(val) : "<none>")) return false;
     auto old_val = val;
     if (include_null) {

--- a/apps/yglutils.h
+++ b/apps/yglutils.h
@@ -57,14 +57,14 @@ uint make_gltexture(
 void update_gltexture(
     int tid, const image<vec4b>& img, bool as_srgb, bool linear, bool mipmap);
 
-uint make_glarraybuffer(const std::vector<float>& buf, bool dynamic = false);
-uint make_glarraybuffer(const std::vector<vec2f>& buf, bool dynamic = false);
-uint make_glarraybuffer(const std::vector<vec3f>& buf, bool dynamic = false);
-uint make_glarraybuffer(const std::vector<vec4f>& buf, bool dynamic = false);
+uint make_glarraybuffer(const vector<float>& buf, bool dynamic = false);
+uint make_glarraybuffer(const vector<vec2f>& buf, bool dynamic = false);
+uint make_glarraybuffer(const vector<vec3f>& buf, bool dynamic = false);
+uint make_glarraybuffer(const vector<vec4f>& buf, bool dynamic = false);
 
-uint make_glelementbuffer(const std::vector<int>& buf, bool dynamic = false);
-uint make_glelementbuffer(const std::vector<vec2i>& buf, bool dynamic = false);
-uint make_glelementbuffer(const std::vector<vec3i>& buf, bool dynamic = false);
+uint make_glelementbuffer(const vector<int>& buf, bool dynamic = false);
+uint make_glelementbuffer(const vector<vec2i>& buf, bool dynamic = false);
+uint make_glelementbuffer(const vector<vec3i>& buf, bool dynamic = false);
 
 int get_gluniform_location(uint pid, const char* name);
 
@@ -147,7 +147,7 @@ bool begin_header_glwidget(glwindow* win, const char* title);
 void end_header_glwidget(glwindow* win);
 
 void draw_label_glwidgets(
-    glwindow* win, const char* lbl, const std::string& txt);
+    glwindow* win, const char* lbl, const string& txt);
 void draw_label_glwidgets(glwindow* win, const char* lbl, const char* fmt, ...);
 
 bool begin_header_widget(glwindow* win, const char* label);
@@ -158,7 +158,7 @@ void continue_glwidgets_line(glwindow* win);
 
 bool draw_button_glwidget(glwindow* win, const char* lbl);
 
-bool draw_textinput_glwidget(glwindow* win, const char* lbl, std::string& val);
+bool draw_textinput_glwidget(glwindow* win, const char* lbl, string& val);
 bool draw_slider_glwidget(
     glwindow* win, const char* lbl, float& val, float min, float max);
 bool draw_slider_glwidget(
@@ -209,27 +209,27 @@ void begin_selectabletreeleaf_glwidget(
     glwindow* win, const char* lbl, void*& selection, void* content);
 
 bool draw_combobox_glwidget(glwindow* win, const char* lbl, int& idx,
-    const std::vector<std::string>& labels);
-bool draw_combobox_glwidget(glwindow* win, const char* lbl, std::string& val,
-    const std::vector<std::string>& labels);
+    const vector<string>& labels);
+bool draw_combobox_glwidget(glwindow* win, const char* lbl, string& val,
+    const vector<string>& labels);
 bool draw_combobox_glwidget(glwindow* win, const char* lbl, int& idx,
-    const std::vector<void*>& vals, const char* (*label)(void*));
+    const vector<void*>& vals, const char* (*label)(void*));
 bool draw_combobox_glwidget(glwindow* win, const char* lbl, void*& val,
-    const std::vector<void*>& vals, const char* (*label)(void*),
+    const vector<void*>& vals, const char* (*label)(void*),
     bool                      include_null);
 
 template <typename T>
 bool draw_combobox_glwidget(
-    glwindow* win, const char* lbl, int& idx, const std::vector<T*>& vals) {
-    return draw_combobox_glwidget(win, lbl, idx, (const std::vector<void*>&)vals,
+    glwindow* win, const char* lbl, int& idx, const vector<T*>& vals) {
+    return draw_combobox_glwidget(win, lbl, idx, (const vector<void*>&)vals,
         [](void* val) { return ((T*)val)->name.c_str(); });
 }
 
 template <typename T>
 bool draw_combobox_glwidget(glwindow* win, const char* lbl, T*& val,
-    const std::vector<T*>& vals, bool include_null) {
+    const vector<T*>& vals, bool include_null) {
     return draw_combobox_glwidget(win, lbl, (void*&)val,
-        (const std::vector<void*>&)vals,
+        (const vector<void*>&)vals,
         [](void* val) { return ((T*)val)->name.c_str(); }, include_null);
 }
 

--- a/apps/yglutils.h
+++ b/apps/yglutils.h
@@ -146,8 +146,7 @@ bool begin_glwidgets_window(glwindow* win, const char* title);
 bool begin_header_glwidget(glwindow* win, const char* title);
 void end_header_glwidget(glwindow* win);
 
-void draw_label_glwidgets(
-    glwindow* win, const char* lbl, const string& txt);
+void draw_label_glwidgets(glwindow* win, const char* lbl, const string& txt);
 void draw_label_glwidgets(glwindow* win, const char* lbl, const char* fmt, ...);
 
 bool begin_header_widget(glwindow* win, const char* label);
@@ -208,15 +207,14 @@ bool begin_selectabletreenode_glwidget(
 void begin_selectabletreeleaf_glwidget(
     glwindow* win, const char* lbl, void*& selection, void* content);
 
-bool draw_combobox_glwidget(glwindow* win, const char* lbl, int& idx,
-    const vector<string>& labels);
-bool draw_combobox_glwidget(glwindow* win, const char* lbl, string& val,
-    const vector<string>& labels);
+bool draw_combobox_glwidget(
+    glwindow* win, const char* lbl, int& idx, const vector<string>& labels);
+bool draw_combobox_glwidget(
+    glwindow* win, const char* lbl, string& val, const vector<string>& labels);
 bool draw_combobox_glwidget(glwindow* win, const char* lbl, int& idx,
     const vector<void*>& vals, const char* (*label)(void*));
 bool draw_combobox_glwidget(glwindow* win, const char* lbl, void*& val,
-    const vector<void*>& vals, const char* (*label)(void*),
-    bool                      include_null);
+    const vector<void*>& vals, const char* (*label)(void*), bool include_null);
 
 template <typename T>
 bool draw_combobox_glwidget(

--- a/apps/yimproc.cpp
+++ b/apps/yimproc.cpp
@@ -117,8 +117,7 @@ image<vec4f> filter_bilateral(
                     if (ii >= width(img) || jj >= height(img)) continue;
                     auto uv  = vec2f{float(i - ii), float(j - jj)};
                     auto rgb = img[{i, j}] - img[{ii, jj}];
-                    auto w   = exp(-dot(uv, uv) * sw) *
-                             exp(-dot(rgb, rgb) * rw);
+                    auto w = exp(-dot(uv, uv) * sw) * exp(-dot(rgb, rgb) * rw);
                     av += w * img[{ii, jj}];
                     aw += w;
                 }

--- a/apps/yimproc.cpp
+++ b/apps/yimproc.cpp
@@ -32,7 +32,7 @@ using namespace ygl;
 
 #if 0
 template <typename Image>
-Image make_image_grid(const std::vector<Image>& imgs, int tilex) {
+Image make_image_grid(const vector<Image>& imgs, int tilex) {
     auto nimgs = (int)imgs.size();
     auto width = imgs[0].size().x * tilex;
     auto height = imgs[0].size().y * (nimgs / tilex + ((nimgs % tilex) ? 1 : 0));
@@ -63,13 +63,13 @@ Image make_image_grid(const std::vector<Image>& imgs, int tilex) {
 #endif
 
 image<vec4f> filter_bilateral(const image<vec4f>& img, float spatial_sigma,
-    float range_sigma, const std::vector<image<vec4f>>& features,
-    const std::vector<float>& features_sigma) {
+    float range_sigma, const vector<image<vec4f>>& features,
+    const vector<float>& features_sigma) {
     auto filtered     = image<vec4f>{extents(img)};
     auto filter_width = (int)ceil(2.57f * spatial_sigma);
     auto sw           = 1 / (2.0f * spatial_sigma * spatial_sigma);
     auto rw           = 1 / (2.0f * range_sigma * range_sigma);
-    auto fw           = std::vector<float>();
+    auto fw           = vector<float>();
     for (auto feature_sigma : features_sigma)
         fw.push_back(1 / (2.0f * feature_sigma * feature_sigma));
     for (auto j = 0; j < height(img); j++) {
@@ -83,8 +83,8 @@ image<vec4f> filter_bilateral(const image<vec4f>& img, float spatial_sigma,
                     if (ii >= width(img) || jj >= height(img)) continue;
                     auto uv  = vec2f{float(i - ii), float(j - jj)};
                     auto rgb = img[{i, j}] - img[{ii, jj}];
-                    auto w   = (float)std::exp(-dot(uv, uv) * sw) *
-                             (float)std::exp(-dot(rgb, rgb) * rw);
+                    auto w   = (float)exp(-dot(uv, uv) * sw) *
+                             (float)exp(-dot(rgb, rgb) * rw);
                     for (auto fi = 0; fi < features.size(); fi++) {
                         auto feat = features[fi][{i, j}] -
                                     features[fi][{ii, jj}];
@@ -117,8 +117,8 @@ image<vec4f> filter_bilateral(
                     if (ii >= width(img) || jj >= height(img)) continue;
                     auto uv  = vec2f{float(i - ii), float(j - jj)};
                     auto rgb = img[{i, j}] - img[{ii, jj}];
-                    auto w   = std::exp(-dot(uv, uv) * sw) *
-                             std::exp(-dot(rgb, rgb) * rw);
+                    auto w   = exp(-dot(uv, uv) * sw) *
+                             exp(-dot(rgb, rgb) * rw);
                     av += w * img[{ii, jj}];
                     aw += w;
                 }

--- a/apps/yimview.cpp
+++ b/apps/yimview.cpp
@@ -38,9 +38,9 @@ struct image_stats {
 
 struct app_image {
     // original data
-    string  filename;  // filename
-    string  outname;   // output filename for display
-    string  name;
+    string       filename;  // filename
+    string       outname;   // output filename for display
+    string       name;
     image<vec4f> img;
     bool         is_hdr = false;
 
@@ -80,7 +80,7 @@ struct app_image {
 struct app_state {
     // images
     vector<app_image*> imgs;
-    int                     img_id = 0;
+    int                img_id = 0;
 
     ~app_state() {
         for (auto img : imgs) delete img;
@@ -154,7 +154,7 @@ void load_image_async(app_image* img) {
 
 // save an image
 void save_image_async(app_image* img) {
-    if(is_hdr_filename(img->outname)) {
+    if (is_hdr_filename(img->outname)) {
         if (!save_image4b(img->outname, float_to_byte(img->display))) {
             img->error_msg = "error saving image";
         }
@@ -166,9 +166,8 @@ void save_image_async(app_image* img) {
 }
 
 // add a new image
-void add_new_image(app_state* app, const string& filename,
-    const string& outname, float exposure = 0, bool filmic = false,
-    bool srgb = true) {
+void add_new_image(app_state* app, const string& filename, const string& outname,
+    float exposure = 0, bool filmic = false, bool srgb = true) {
     auto img      = new app_image();
     img->filename = filename;
     img->outname  = (outname == "") ?

--- a/apps/yimview.cpp
+++ b/apps/yimview.cpp
@@ -57,9 +57,9 @@ struct app_image {
     bool  srgb     = true;
 
     // computation futures
-    std::atomic<bool> load_done, display_done, stats_done, texture_done;
+    atomic<bool> load_done, display_done, stats_done, texture_done;
     thread       load_thread, display_thread, stats_thread, save_thread;
-    std::atomic<bool> display_stop;
+    atomic<bool> display_stop;
     string       error_msg = "";
 
     // viewing properties

--- a/apps/yimview.cpp
+++ b/apps/yimview.cpp
@@ -38,9 +38,9 @@ struct image_stats {
 
 struct app_image {
     // original data
-    std::string  filename;  // filename
-    std::string  outname;   // output filename for display
-    std::string  name;
+    string  filename;  // filename
+    string  outname;   // output filename for display
+    string  name;
     image<vec4f> img;
     bool         is_hdr = false;
 
@@ -58,9 +58,9 @@ struct app_image {
 
     // computation futures
     std::atomic<bool> load_done, display_done, stats_done, texture_done;
-    std::thread       load_thread, display_thread, stats_thread, save_thread;
+    thread       load_thread, display_thread, stats_thread, save_thread;
     std::atomic<bool> display_stop;
-    std::string       error_msg = "";
+    string       error_msg = "";
 
     // viewing properties
     vec2f imcenter    = zero2f;
@@ -79,7 +79,7 @@ struct app_image {
 
 struct app_state {
     // images
-    std::vector<app_image*> imgs;
+    vector<app_image*> imgs;
     int                     img_id = 0;
 
     ~app_state() {
@@ -104,10 +104,10 @@ void update_display_async(app_image* img) {
     img->display_done = false;
     img->texture_done = false;
     if (width(img->img) * height(img->img) > 1024 * 1024) {
-        auto nthreads = std::thread::hardware_concurrency();
-        auto threads  = std::vector<std::thread>();
+        auto nthreads = thread::hardware_concurrency();
+        auto threads  = vector<thread>();
         for (auto tid = 0; tid < nthreads; tid++) {
-            threads.push_back(std::thread([img, tid, nthreads]() {
+            threads.push_back(thread([img, tid, nthreads]() {
                 for (auto j = tid; j < height(img->img); j += nthreads) {
                     if (img->display_stop) break;
                     for (auto i = 0; i < width(img->img); i++) {
@@ -148,8 +148,8 @@ void load_image_async(app_image* img) {
     img->display   = img->img;
     printf("load: %s\n", format_duration(get_time() - start).c_str());
     fflush(stdout);
-    img->display_thread = std::thread(update_display_async, img);
-    img->stats_thread   = std::thread(update_stats_async, img);
+    img->display_thread = thread(update_display_async, img);
+    img->stats_thread   = thread(update_stats_async, img);
 }
 
 // save an image
@@ -166,8 +166,8 @@ void save_image_async(app_image* img) {
 }
 
 // add a new image
-void add_new_image(app_state* app, const std::string& filename,
-    const std::string& outname, float exposure = 0, bool filmic = false,
+void add_new_image(app_state* app, const string& filename,
+    const string& outname, float exposure = 0, bool filmic = false,
     bool srgb = true) {
     auto img      = new app_image();
     img->filename = filename;
@@ -179,7 +179,7 @@ void add_new_image(app_state* app, const std::string& filename,
     img->exposure    = exposure;
     img->filmic      = filmic;
     img->srgb        = srgb;
-    img->load_thread = std::thread(load_image_async, img);
+    img->load_thread = thread(load_image_async, img);
     app->imgs.push_back(img);
     app->img_id = (int)app->imgs.size() - 1;
 }
@@ -196,10 +196,10 @@ void draw_glwidgets(glwindow* win) {
             draw_textinput_glwidget(win, "outname", img->outname);
             if (draw_button_glwidget(win, "save display")) {
                 if (img->display_done) {
-                    img->save_thread = std::thread(save_image_async, img);
+                    img->save_thread = thread(save_image_async, img);
                 }
             }
-            auto status = std::string();
+            auto status = string();
             if (img->error_msg != "")
                 status = "error: " + img->error_msg;
             else if (!img->load_done)
@@ -250,7 +250,7 @@ void draw_glwidgets(glwindow* win) {
         }
         if (img->save_thread.joinable()) img->save_thread.join();
         img->display_stop   = false;
-        img->display_thread = std::thread(update_display_async, img);
+        img->display_thread = thread(update_display_async, img);
     }
 }
 
@@ -345,7 +345,7 @@ int main(int argc, char* argv[]) {
     //     parser, "--quiet,-q", false, "Print only errors messages");
     auto outfilename = parse_arg(parser, "--out,-o", ""s, "image out filename");
     auto filenames   = parse_args(
-        parser, "images", std::vector<std::string>{}, "image filenames", true);
+        parser, "images", vector<string>{}, "image filenames", true);
     check_cmdline(parser);
 
     // loading images

--- a/apps/yitrace.cpp
+++ b/apps/yitrace.cpp
@@ -38,8 +38,8 @@ struct app_state {
     bvh_tree* bvh = nullptr;
 
     // rendering params
-    std::string  filename   = "scene.json";
-    std::string  imfilename = "out.obj";
+    string  filename   = "scene.json";
+    string  imfilename = "out.obj";
     trace_params params     = {};
 
     // rendering state
@@ -52,7 +52,7 @@ struct app_state {
     bool                                       zoom_to_fit  = true;
     bool                                       widgets_open = false;
     void*                                      selection    = nullptr;
-    std::vector<std::pair<std::string, void*>> update_list;
+    vector<pair<string, void*>> update_list;
     bool                                       navigation_fps = false;
     bool                                       quiet          = false;
     int64_t                                    trace_start    = 0;
@@ -78,7 +78,7 @@ void draw_glwidgets(glwindow* win) {
             draw_label_glwidgets(win, "image", "%d x %d @ %d",
                 width(app->state->img), height(app->state->img),
                 app->state->sample);
-            auto cam_names = std::vector<std::string>();
+            auto cam_names = vector<string>();
             for (auto cam : app->scn->cameras) cam_names.push_back(cam->name);
             auto edited = 0;
             edited += draw_combobox_glwidget(

--- a/apps/yitrace.cpp
+++ b/apps/yitrace.cpp
@@ -38,8 +38,8 @@ struct app_state {
     bvh_tree* bvh = nullptr;
 
     // rendering params
-    string  filename   = "scene.json";
-    string  imfilename = "out.obj";
+    string       filename   = "scene.json";
+    string       imfilename = "out.obj";
     trace_params params     = {};
 
     // rendering state
@@ -47,16 +47,16 @@ struct app_state {
     trace_lights* lights = nullptr;
 
     // view image
-    vec2f                                      imcenter     = zero2f;
-    float                                      imscale      = 1;
-    bool                                       zoom_to_fit  = true;
-    bool                                       widgets_open = false;
-    void*                                      selection    = nullptr;
+    vec2f                        imcenter     = zero2f;
+    float                        imscale      = 1;
+    bool                         zoom_to_fit  = true;
+    bool                         widgets_open = false;
+    void*                        selection    = nullptr;
     vector<tuple<string, void*>> update_list;
-    bool                                       navigation_fps = false;
-    bool                                       quiet          = false;
-    int64_t                                    trace_start    = 0;
-    uint                                       gl_txt         = 0;
+    bool                         navigation_fps = false;
+    bool                         quiet          = false;
+    int64_t                      trace_start    = 0;
+    uint                         gl_txt         = 0;
 
     ~app_state() {
         if (scn) delete scn;

--- a/apps/yitrace.cpp
+++ b/apps/yitrace.cpp
@@ -52,7 +52,7 @@ struct app_state {
     bool                                       zoom_to_fit  = true;
     bool                                       widgets_open = false;
     void*                                      selection    = nullptr;
-    vector<pair<string, void*>> update_list;
+    vector<tuple<string, void*>> update_list;
     bool                                       navigation_fps = false;
     bool                                       quiet          = false;
     int64_t                                    trace_start    = 0;
@@ -163,17 +163,17 @@ bool update(app_state* app) {
 
     // update BVH
     for (auto& sel : app->update_list) {
-        if (sel.first == "shape") {
+        if (get<0>(sel) == "shape") {
             for (auto sid = 0; sid < app->scn->shapes.size(); sid++) {
-                if (app->scn->shapes[sid] == sel.second) {
-                    refit_bvh((shape*)sel.second, app->bvh->shape_bvhs[sid]);
+                if (app->scn->shapes[sid] == get<1>(sel)) {
+                    refit_bvh((shape*)get<1>(sel), app->bvh->shape_bvhs[sid]);
                     break;
                 }
             }
             refit_bvh(app->scn, app->bvh);
         }
-        if (sel.first == "instance") { refit_bvh(app->scn, app->bvh); }
-        if (sel.first == "node") {
+        if (get<0>(sel) == "instance") { refit_bvh(app->scn, app->bvh); }
+        if (get<0>(sel) == "node") {
             update_transforms(app->scn, 0);
             refit_bvh(app->scn, app->bvh);
         }

--- a/apps/yobjproc.cpp
+++ b/apps/yobjproc.cpp
@@ -30,7 +30,7 @@
 #include "../yocto/yglio.h"
 using namespace ygl;
 
-std::string to_string(const obj_vertex& v) {
+string to_string(const obj_vertex& v) {
     auto s = std::to_string(v.pos);
     if (v.texcoord) {
         s += "/" + std::to_string(v.texcoord);
@@ -90,7 +90,7 @@ int main(int argc, char* argv[]) {
         fprintf(fs, "vt %6g %6g\n", v.x, v.y);
         ntexcoord += 1;
     };
-    cb.face = [&](const std::vector<obj_vertex>& verts) {
+    cb.face = [&](const vector<obj_vertex>& verts) {
         fprintf(fs, "f");
         for (auto v : verts) fprintf(fs, " %s", to_string(v).c_str());
         fprintf(fs, "\n");
@@ -99,33 +99,33 @@ int main(int argc, char* argv[]) {
         if (verts.size() == 4) nquads += 1;
         if (verts.size() > 4) npolys += 1;
     };
-    cb.line = [&](const std::vector<obj_vertex>& verts) {
+    cb.line = [&](const vector<obj_vertex>& verts) {
         fprintf(fs, "l");
         for (auto v : verts) fprintf(fs, " %s", to_string(v).c_str());
         fprintf(fs, "\n");
         nplines += 1;
         nlines += (int)verts.size() - 1;
     };
-    cb.point = [&](const std::vector<obj_vertex>& verts) {
+    cb.point = [&](const vector<obj_vertex>& verts) {
         fprintf(fs, "p");
         for (auto v : verts) fprintf(fs, " %s", to_string(v).c_str());
         fprintf(fs, "\n");
         nppoints += 1;
         npoints += (int)verts.size();
     };
-    cb.object = [&](const std::string& name) {
+    cb.object = [&](const string& name) {
         fprintf(fs, "o %s\n", name.c_str());
         nobjects += 1;
     };
-    cb.group = [&](const std::string& name) {
+    cb.group = [&](const string& name) {
         fprintf(fs, "g %s\n", name.c_str());
         ngroups += 1;
     };
-    cb.usemtl = [&](const std::string& name) {
+    cb.usemtl = [&](const string& name) {
         fprintf(fs, "usemtl %s\n", name.c_str());
         nusemtl += 1;
     };
-    cb.mtllib = [&](const std::string& name) {
+    cb.mtllib = [&](const string& name) {
         fprintf(fs, "mtllib %s\n", name.c_str());
     };
     cb.material = [&](auto&) { nmaterials += 1; };

--- a/apps/ysceneui.h
+++ b/apps/ysceneui.h
@@ -324,7 +324,7 @@ inline bool draw_glwidgets_scene_inspector(
 
 inline bool draw_glwidgets_scene_tree(glwindow* win, const string& lbl,
     scene* scn, void*& sel,
-    vector<pair<string, void*>>& update_list, int height) {
+    vector<tuple<string, void*>>& update_list, int height) {
     if (!scn) return false;
     draw_glwidgets_scene_tree(win, scn, sel);
     auto update_len = update_list.size();
@@ -353,7 +353,7 @@ inline bool draw_glwidgets_scene_tree(glwindow* win, const string& lbl,
 
 inline bool draw_glwidgets_scene_inspector(glwindow* win,
     const string& lbl, scene* scn, void*& sel,
-    vector<pair<string, void*>>& update_list, int height) {
+    vector<tuple<string, void*>>& update_list, int height) {
     if (!scn || !sel) return false;
     begin_child_glwidget(win, "scrolling scene inspector", {0, height});
 

--- a/apps/ysceneui.h
+++ b/apps/ysceneui.h
@@ -34,10 +34,8 @@
 #include "yglutils.h"
 using namespace ygl;
 
-#include <map>
-
-inline const std::map<animation_type, std::string>& animation_type_names() {
-    static auto names = std::map<animation_type, std::string>{
+inline const map<animation_type, string>& animation_type_names() {
+    static auto names = map<animation_type, string>{
         {animation_type::linear, "linear"},
         {animation_type::step, "step"},
         {animation_type::bezier, "bezier"},
@@ -47,11 +45,11 @@ inline const std::map<animation_type, std::string>& animation_type_names() {
 
 template <typename T>
 inline void draw_scene_tree_glwidgets_rec(
-    glwindow* win, const std::string& lbl_, T* val, void*& sel) {}
+    glwindow* win, const string& lbl_, T* val, void*& sel) {}
 
 template <typename T>
 inline void draw_glwidgets_scene_tree(
-    glwindow* win, const std::string& lbl_, T* val, void*& sel) {
+    glwindow* win, const string& lbl_, T* val, void*& sel) {
     if (!val) return;
     auto lbl = val->name;
     if (!lbl_.empty()) lbl = lbl_ + ": " + val->name;
@@ -63,7 +61,7 @@ inline void draw_glwidgets_scene_tree(
 
 template <>
 inline void draw_scene_tree_glwidgets_rec<instance>(
-    glwindow* win, const std::string& lbl_, instance* val, void*& sel) {
+    glwindow* win, const string& lbl_, instance* val, void*& sel) {
     draw_glwidgets_scene_tree(win, "shp", val->shp, sel);
     draw_glwidgets_scene_tree(win, "sbd", val->sbd, sel);
     draw_glwidgets_scene_tree(win, "mat", val->mat, sel);
@@ -71,7 +69,7 @@ inline void draw_scene_tree_glwidgets_rec<instance>(
 
 template <>
 inline void draw_scene_tree_glwidgets_rec<material>(
-    glwindow* win, const std::string& lbl_, material* val, void*& sel) {
+    glwindow* win, const string& lbl_, material* val, void*& sel) {
     draw_glwidgets_scene_tree(win, "ke", val->ke_txt, sel);
     draw_glwidgets_scene_tree(win, "kd", val->kd_txt, sel);
     draw_glwidgets_scene_tree(win, "ks", val->ks_txt, sel);
@@ -81,27 +79,27 @@ inline void draw_scene_tree_glwidgets_rec<material>(
 }
 template <>
 inline void draw_scene_tree_glwidgets_rec<environment>(
-    glwindow* win, const std::string& lbl_, environment* val, void*& sel) {
+    glwindow* win, const string& lbl_, environment* val, void*& sel) {
     draw_glwidgets_scene_tree(win, "ke", val->ke_txt, sel);
 }
 template <>
 inline void draw_scene_tree_glwidgets_rec<node>(
-    glwindow* win, const std::string& lbl_, node* val, void*& sel) {
+    glwindow* win, const string& lbl_, node* val, void*& sel) {
     draw_glwidgets_scene_tree(win, "ist", val->ist, sel);
     draw_glwidgets_scene_tree(win, "cam", val->cam, sel);
     draw_glwidgets_scene_tree(win, "env", val->env, sel);
     draw_glwidgets_scene_tree(win, "par", val->parent, sel);
     auto cid = 0;
     for (auto ch : val->children) {
-        draw_glwidgets_scene_tree(win, "ch" + std::to_string(cid++), ch, sel);
+        draw_glwidgets_scene_tree(win, "ch" + to_string(cid++), ch, sel);
     }
 }
 template <>
 inline void draw_scene_tree_glwidgets_rec<animation>(
-    glwindow* win, const std::string& lbl_, animation* val, void*& sel) {
+    glwindow* win, const string& lbl_, animation* val, void*& sel) {
     auto tid = 0;
     for (auto tg : val->targets) {
-        draw_glwidgets_scene_tree(win, "tg" + std::to_string(tid++), tg, sel);
+        draw_glwidgets_scene_tree(win, "tg" + to_string(tid++), tg, sel);
     }
 }
 
@@ -324,9 +322,9 @@ inline bool draw_glwidgets_scene_inspector(
     return edited;
 }
 
-inline bool draw_glwidgets_scene_tree(glwindow* win, const std::string& lbl,
+inline bool draw_glwidgets_scene_tree(glwindow* win, const string& lbl,
     scene* scn, void*& sel,
-    std::vector<std::pair<std::string, void*>>& update_list, int height) {
+    vector<pair<string, void*>>& update_list, int height) {
     if (!scn) return false;
     draw_glwidgets_scene_tree(win, scn, sel);
     auto update_len = update_list.size();
@@ -354,8 +352,8 @@ inline bool draw_glwidgets_scene_tree(glwindow* win, const std::string& lbl,
 }
 
 inline bool draw_glwidgets_scene_inspector(glwindow* win,
-    const std::string& lbl, scene* scn, void*& sel,
-    std::vector<std::pair<std::string, void*>>& update_list, int height) {
+    const string& lbl, scene* scn, void*& sel,
+    vector<pair<string, void*>>& update_list, int height) {
     if (!scn || !sel) return false;
     begin_child_glwidget(win, "scrolling scene inspector", {0, height});
 

--- a/apps/ysceneui.h
+++ b/apps/ysceneui.h
@@ -323,8 +323,8 @@ inline bool draw_glwidgets_scene_inspector(
 }
 
 inline bool draw_glwidgets_scene_tree(glwindow* win, const string& lbl,
-    scene* scn, void*& sel,
-    vector<tuple<string, void*>>& update_list, int height) {
+    scene* scn, void*& sel, vector<tuple<string, void*>>& update_list,
+    int height) {
     if (!scn) return false;
     draw_glwidgets_scene_tree(win, scn, sel);
     auto update_len = update_list.size();
@@ -351,9 +351,9 @@ inline bool draw_glwidgets_scene_tree(glwindow* win, const string& lbl,
     return update_list.size() != update_len;
 }
 
-inline bool draw_glwidgets_scene_inspector(glwindow* win,
-    const string& lbl, scene* scn, void*& sel,
-    vector<tuple<string, void*>>& update_list, int height) {
+inline bool draw_glwidgets_scene_inspector(glwindow* win, const string& lbl,
+    scene* scn, void*& sel, vector<tuple<string, void*>>& update_list,
+    int height) {
     if (!scn || !sel) return false;
     begin_child_glwidget(win, "scrolling scene inspector", {0, height});
 

--- a/apps/yscnproc.cpp
+++ b/apps/yscnproc.cpp
@@ -30,7 +30,7 @@
 #include "../yocto/yglio.h"
 using namespace ygl;
 
-bool mkdir(const std::string& dir) {
+bool mkdir(const string& dir) {
     if (dir == "" || dir == "." || dir == ".." || dir == "./" || dir == "../")
         return true;
 #ifndef _MSC_VER

--- a/apps/ytrace.cpp
+++ b/apps/ytrace.cpp
@@ -117,7 +117,7 @@ int main(int argc, char* argv[]) {
             format_duration(get_time() - block_start).c_str());
         if (save_batch) {
             auto filename = replace_extension(imfilename,
-                std::to_string(state->sample) + "." + get_extension(imfilename));
+                to_string(state->sample) + "." + get_extension(imfilename));
             log_info("saving image {}", filename.c_str());
             if (!save_tonemapped_image(
                     filename, state->img, exposure, gamma, filmic))

--- a/apps/ytrace2.cpp
+++ b/apps/ytrace2.cpp
@@ -93,7 +93,7 @@ int main(int argc, char* argv[]) {
         done = trace_samples(state, scn, bvh, lights, params);
         if (save_batch) {
             auto filename = replace_extension(imfilename,
-                std::to_string(state->sample) + "." + get_extension(imfilename));
+                to_string(state->sample) + "." + get_extension(imfilename));
             printf("saving image %s\n", filename.c_str());
             save_tonemapped_image(filename, state->img, exposure, gamma, filmic);
         }

--- a/apps/yview.cpp
+++ b/apps/yview.cpp
@@ -69,7 +69,7 @@ struct app_state {
     bool                                       widgets_open   = false;
     bool                                       navigation_fps = false;
     void*                                      selection      = nullptr;
-    vector<pair<string, void*>> update_list;
+    vector<tuple<string, void*>> update_list;
     float                                      time       = 0;
     string                                anim_group = "";
     vec2f                                      time_range = zero2f;
@@ -94,19 +94,19 @@ void draw(glwindow* win) {
 
     static auto last_time = 0.0f;
     for (auto& sel : app->update_list) {
-        if (sel.first == "texture") {
+        if (get<0>(sel) == "texture") {
             // TODO: update texture
             printf("texture update not supported\n");
         }
-        if (sel.first == "subdiv") {
+        if (get<0>(sel) == "subdiv") {
             // TODO: update subdiv
             printf("subdiv update not supported\n");
         }
-        if (sel.first == "shape") {
+        if (get<0>(sel) == "shape") {
             // TODO: update shape
             printf("shape update not supported\n");
         }
-        if (sel.first == "node" || sel.first == "animation" ||
+        if (get<0>(sel) == "node" || get<0>(sel) == "animation" ||
             app->time != last_time) {
             update_transforms(app->scn, app->time, app->anim_group);
             last_time = app->time;

--- a/apps/yview.cpp
+++ b/apps/yview.cpp
@@ -720,7 +720,7 @@ void run_ui(app_state* app) {
 unordered_map<string, unordered_map<string, string>>
 load_ini(const string& filename) {
     auto f = fopen(filename.c_str(), "rt");
-    if (!f) throw std::runtime_error("cannot open " + filename);
+    if (!f) throw runtime_error("cannot open " + filename);
     auto ret       = unordered_map<string,
         unordered_map<string, string>>();
     auto cur_group = string();
@@ -733,7 +733,7 @@ load_ini(const string& filename) {
         if (line.front() == ';') continue;
         if (line.front() == '#') continue;
         if (line.front() == '[') {
-            if (line.back() != ']') throw std::runtime_error("bad INI format");
+            if (line.back() != ']') throw runtime_error("bad INI format");
             cur_group      = line.substr(1, line.length() - 2);
             ret[cur_group] = {};
         } else if (line.find('=') != line.npos) {
@@ -741,7 +741,7 @@ load_ini(const string& filename) {
             auto val            = line.substr(line.find('=') + 1);
             ret[cur_group][var] = val;
         } else {
-            throw std::runtime_error("bad INI format");
+            throw runtime_error("bad INI format");
         }
     }
 

--- a/apps/yview.cpp
+++ b/apps/yview.cpp
@@ -39,8 +39,8 @@ struct draw_glshape_vbos {
 
 struct draw_glstate {
     unsigned int                                        gl_prog = 0;
-    std::unordered_map<const shape*, draw_glshape_vbos> shp_vbos;
-    std::unordered_map<const texture*, unsigned int>    txt_id;
+    unordered_map<const shape*, draw_glshape_vbos> shp_vbos;
+    unordered_map<const texture*, unsigned int>    txt_id;
 };
 
 // Application state
@@ -49,9 +49,9 @@ struct app_state {
     scene* scn = nullptr;
 
     // parameters
-    std::string filename    = "scene.json";  // scene name
-    std::string imfilename  = "out.png";     // output image
-    std::string outfilename = "scene.json";  // save scene name
+    string filename    = "scene.json";  // scene name
+    string imfilename  = "out.png";     // output image
+    string outfilename = "scene.json";  // save scene name
     int         camid       = 0;             // camera id
     int         resolution  = 512;           // image resolution
     bool        wireframe   = false;         // wireframe drawing
@@ -69,9 +69,9 @@ struct app_state {
     bool                                       widgets_open   = false;
     bool                                       navigation_fps = false;
     void*                                      selection      = nullptr;
-    std::vector<std::pair<std::string, void*>> update_list;
+    vector<pair<string, void*>> update_list;
     float                                      time       = 0;
-    std::string                                anim_group = "";
+    string                                anim_group = "";
     vec2f                                      time_range = zero2f;
     bool                                       animate    = false;
 
@@ -566,9 +566,9 @@ void draw_glscene(const draw_glstate* state, const scene* scn,
     set_gluniform(state->gl_prog, "gamma", gamma);
 
     if (!eyelight) {
-        auto lights_pos  = std::vector<vec3f>();
-        auto lights_ke   = std::vector<vec3f>();
-        auto lights_type = std::vector<int>();
+        auto lights_pos  = vector<vec3f>();
+        auto lights_ke   = vector<vec3f>();
+        auto lights_type = vector<int>();
         for (auto lgt : scn->instances) {
             if (lgt->mat->ke == zero3f) continue;
             if (lights_pos.size() >= 16) break;
@@ -595,7 +595,7 @@ void draw_glscene(const draw_glstate* state, const scene* scn,
         set_gluniform(state->gl_prog, "lamb", zero3f);
         set_gluniform(state->gl_prog, "lnum", (int)lights_pos.size());
         for (auto i = 0; i < lights_pos.size(); i++) {
-            auto is = std::to_string(i);
+            auto is = to_string(i);
             set_gluniform(
                 state->gl_prog, ("lpos[" + is + "]").c_str(), lights_pos[i]);
             set_gluniform(
@@ -717,18 +717,18 @@ void run_ui(app_state* app) {
 }
 
 // Load INI file. The implementation does not handle escaping.
-std::unordered_map<std::string, std::unordered_map<std::string, std::string>>
-load_ini(const std::string& filename) {
+unordered_map<string, unordered_map<string, string>>
+load_ini(const string& filename) {
     auto f = fopen(filename.c_str(), "rt");
     if (!f) throw std::runtime_error("cannot open " + filename);
-    auto ret       = std::unordered_map<std::string,
-        std::unordered_map<std::string, std::string>>();
-    auto cur_group = std::string();
+    auto ret       = unordered_map<string,
+        unordered_map<string, string>>();
+    auto cur_group = string();
     ret[""]        = {};
 
     char buf[4096];
     while (fgets(buf, 4096, f)) {
-        auto line = std::string(buf);
+        auto line = string(buf);
         if (line.empty()) continue;
         if (line.front() == ';') continue;
         if (line.front() == '#') continue;

--- a/apps/yview.cpp
+++ b/apps/yview.cpp
@@ -38,7 +38,7 @@ struct draw_glshape_vbos {
 };
 
 struct draw_glstate {
-    unsigned int                                        gl_prog = 0;
+    unsigned int                                   gl_prog = 0;
     unordered_map<const shape*, draw_glshape_vbos> shp_vbos;
     unordered_map<const texture*, unsigned int>    txt_id;
 };
@@ -52,28 +52,28 @@ struct app_state {
     string filename    = "scene.json";  // scene name
     string imfilename  = "out.png";     // output image
     string outfilename = "scene.json";  // save scene name
-    int         camid       = 0;             // camera id
-    int         resolution  = 512;           // image resolution
-    bool        wireframe   = false;         // wireframe drawing
-    bool        edges       = false;         // draw edges
-    float       edge_offset = 0.01f;         // offset for edges
-    bool        eyelight    = false;         // camera light mode
-    float       exposure    = 0;             // exposure
-    float       gamma       = 2.2f;          // gamma
-    vec3f       ambient     = {0, 0, 0};     // ambient lighting
-    float       near_plane  = 0.01f;         // near plane
-    float       far_plane   = 10000.0f;      // far plane
+    int    camid       = 0;             // camera id
+    int    resolution  = 512;           // image resolution
+    bool   wireframe   = false;         // wireframe drawing
+    bool   edges       = false;         // draw edges
+    float  edge_offset = 0.01f;         // offset for edges
+    bool   eyelight    = false;         // camera light mode
+    float  exposure    = 0;             // exposure
+    float  gamma       = 2.2f;          // gamma
+    vec3f  ambient     = {0, 0, 0};     // ambient lighting
+    float  near_plane  = 0.01f;         // near plane
+    float  far_plane   = 10000.0f;      // far plane
 
     draw_glstate* state = nullptr;
 
-    bool                                       widgets_open   = false;
-    bool                                       navigation_fps = false;
-    void*                                      selection      = nullptr;
+    bool                         widgets_open   = false;
+    bool                         navigation_fps = false;
+    void*                        selection      = nullptr;
     vector<tuple<string, void*>> update_list;
-    float                                      time       = 0;
-    string                                anim_group = "";
-    vec2f                                      time_range = zero2f;
-    bool                                       animate    = false;
+    float                        time       = 0;
+    string                       anim_group = "";
+    vec2f                        time_range = zero2f;
+    bool                         animate    = false;
 
     ~app_state() {
         if (scn) delete scn;
@@ -717,12 +717,11 @@ void run_ui(app_state* app) {
 }
 
 // Load INI file. The implementation does not handle escaping.
-unordered_map<string, unordered_map<string, string>>
-load_ini(const string& filename) {
+unordered_map<string, unordered_map<string, string>> load_ini(
+    const string& filename) {
     auto f = fopen(filename.c_str(), "rt");
     if (!f) throw runtime_error("cannot open " + filename);
-    auto ret       = unordered_map<string,
-        unordered_map<string, string>>();
+    auto ret       = unordered_map<string, unordered_map<string, string>>();
     auto cur_group = string();
     ret[""]        = {};
 

--- a/yocto/ygl.cpp
+++ b/yocto/ygl.cpp
@@ -348,9 +348,9 @@ vector<vec4f> compute_tangent_space(const vector<vec3i>& triangles,
     for (auto t : triangles) {
         auto tutv = triangle_tangents_fromuv(pos[t.x], pos[t.y], pos[t.z],
             texcoord[t.x], texcoord[t.y], texcoord[t.z]);
-        tutv      = {normalize(tutv.first), normalize(tutv.second)};
-        for (auto vid : {t.x, t.y, t.z}) tangu[vid] += tutv.first;
-        for (auto vid : {t.x, t.y, t.z}) tangv[vid] += tutv.second;
+        tutv      = {normalize(get<0>(tutv)), normalize(get<1>(tutv))};
+        for (auto vid : {t.x, t.y, t.z}) tangu[vid] += get<0>(tutv);
+        for (auto vid : {t.x, t.y, t.z}) tangv[vid] += get<1>(tutv);
     }
     for (auto& t : tangu) t = normalize(t);
     for (auto& t : tangv) t = normalize(t);
@@ -364,7 +364,7 @@ vector<vec4f> compute_tangent_space(const vector<vec3i>& triangles,
 }
 
 // Apply skinning
-pair<vector<vec3f>, vector<vec3f>> compute_skinning(
+tuple<vector<vec3f>, vector<vec3f>> compute_skinning(
     const vector<vec3f>& pos, const vector<vec3f>& norm,
     const vector<vec4f>& weights, const vector<vec4i>& joints,
     const vector<frame3f>& xforms) {
@@ -391,7 +391,7 @@ pair<vector<vec3f>, vector<vec3f>> compute_skinning(
 }
 
 // Apply skinning as specified in Khronos glTF
-pair<vector<vec3f>, vector<vec3f>> compute_matrix_skinning(
+tuple<vector<vec3f>, vector<vec3f>> compute_matrix_skinning(
     const vector<vec3f>& pos, const vector<vec3f>& norm,
     const vector<vec4f>& weights, const vector<vec4i>& joints,
     const vector<mat4f>& xforms) {
@@ -571,7 +571,7 @@ void convert_face_varying(vector<vec4i>& qquads, vector<vec3f>& qpos,
 
 // Subdivide lines.
 template <typename T>
-pair<vector<vec2i>, vector<T>> subdivide_lines(
+tuple<vector<vec2i>, vector<T>> subdivide_lines(
     const vector<vec2i>& lines, const vector<T>& vert) {
     auto nverts = (int)vert.size();
     auto nlines = (int)lines.size();
@@ -593,18 +593,18 @@ pair<vector<vec2i>, vector<T>> subdivide_lines(
     return {tlines, tvert};
 }
 
-template pair<vector<vec2i>, vector<float>> subdivide_lines(
+template tuple<vector<vec2i>, vector<float>> subdivide_lines(
     const vector<vec2i>&, const vector<float>&);
-template pair<vector<vec2i>, vector<vec2f>> subdivide_lines(
+template tuple<vector<vec2i>, vector<vec2f>> subdivide_lines(
     const vector<vec2i>&, const vector<vec2f>&);
-template pair<vector<vec2i>, vector<vec3f>> subdivide_lines(
+template tuple<vector<vec2i>, vector<vec3f>> subdivide_lines(
     const vector<vec2i>&, const vector<vec3f>&);
-template pair<vector<vec2i>, vector<vec4f>> subdivide_lines(
+template tuple<vector<vec2i>, vector<vec4f>> subdivide_lines(
     const vector<vec2i>&, const vector<vec4f>&);
 
 // Subdivide triangle.
 template <typename T>
-pair<vector<vec3i>, vector<T>> subdivide_triangles(
+tuple<vector<vec3i>, vector<T>> subdivide_triangles(
     const vector<vec3i>& triangles, const vector<T>& vert) {
     // get edges
     auto emap  = make_edge_map(triangles);
@@ -638,18 +638,18 @@ pair<vector<vec3i>, vector<T>> subdivide_triangles(
     return {ttriangles, tvert};
 }
 
-template pair<vector<vec3i>, vector<float>> subdivide_triangles(
+template tuple<vector<vec3i>, vector<float>> subdivide_triangles(
     const vector<vec3i>&, const vector<float>&);
-template pair<vector<vec3i>, vector<vec2f>> subdivide_triangles(
+template tuple<vector<vec3i>, vector<vec2f>> subdivide_triangles(
     const vector<vec3i>&, const vector<vec2f>&);
-template pair<vector<vec3i>, vector<vec3f>> subdivide_triangles(
+template tuple<vector<vec3i>, vector<vec3f>> subdivide_triangles(
     const vector<vec3i>&, const vector<vec3f>&);
-template pair<vector<vec3i>, vector<vec4f>> subdivide_triangles(
+template tuple<vector<vec3i>, vector<vec4f>> subdivide_triangles(
     const vector<vec3i>&, const vector<vec4f>&);
 
 // Subdivide quads.
 template <typename T>
-pair<vector<vec4i>, vector<T>> subdivide_quads(
+tuple<vector<vec4i>, vector<T>> subdivide_quads(
     const vector<vec4i>& quads, const vector<T>& vert) {
     // get edges
     auto emap  = make_edge_map(quads);
@@ -703,18 +703,18 @@ pair<vector<vec4i>, vector<T>> subdivide_quads(
     return {tquads, tvert};
 }
 
-template pair<vector<vec4i>, vector<float>> subdivide_quads(
+template tuple<vector<vec4i>, vector<float>> subdivide_quads(
     const vector<vec4i>&, const vector<float>&);
-template pair<vector<vec4i>, vector<vec2f>> subdivide_quads(
+template tuple<vector<vec4i>, vector<vec2f>> subdivide_quads(
     const vector<vec4i>&, const vector<vec2f>&);
-template pair<vector<vec4i>, vector<vec3f>> subdivide_quads(
+template tuple<vector<vec4i>, vector<vec3f>> subdivide_quads(
     const vector<vec4i>&, const vector<vec3f>&);
-template pair<vector<vec4i>, vector<vec4f>> subdivide_quads(
+template tuple<vector<vec4i>, vector<vec4f>> subdivide_quads(
     const vector<vec4i>&, const vector<vec4f>&);
 
 // Subdivide beziers.
 template <typename T>
-pair<vector<vec4i>, vector<T>> subdivide_beziers(
+tuple<vector<vec4i>, vector<T>> subdivide_beziers(
     const vector<vec4i>& beziers, const vector<T>& vert) {
     auto vmap     = unordered_map<int, int>();
     auto tvert    = vector<T>();
@@ -742,18 +742,18 @@ pair<vector<vec4i>, vector<T>> subdivide_beziers(
     return {tbeziers, tvert};
 }
 
-template pair<vector<vec4i>, vector<float>> subdivide_beziers(
+template tuple<vector<vec4i>, vector<float>> subdivide_beziers(
     const vector<vec4i>&, const vector<float>&);
-template pair<vector<vec4i>, vector<vec2f>> subdivide_beziers(
+template tuple<vector<vec4i>, vector<vec2f>> subdivide_beziers(
     const vector<vec4i>&, const vector<vec2f>&);
-template pair<vector<vec4i>, vector<vec3f>> subdivide_beziers(
+template tuple<vector<vec4i>, vector<vec3f>> subdivide_beziers(
     const vector<vec4i>&, const vector<vec3f>&);
-template pair<vector<vec4i>, vector<vec4f>> subdivide_beziers(
+template tuple<vector<vec4i>, vector<vec4f>> subdivide_beziers(
     const vector<vec4i>&, const vector<vec4f>&);
 
 // Subdivide catmullclark.
 template <typename T>
-pair<vector<vec4i>, vector<T>> subdivide_catmullclark(
+tuple<vector<vec4i>, vector<T>> subdivide_catmullclark(
     const vector<vec4i>& quads, const vector<T>& vert,
     bool lock_boundary) {
     // get edges
@@ -873,17 +873,17 @@ pair<vector<vec4i>, vector<T>> subdivide_catmullclark(
     return {tquads, tvert};
 }
 
-template pair<vector<vec4i>, vector<float>> subdivide_catmullclark(
+template tuple<vector<vec4i>, vector<float>> subdivide_catmullclark(
     const vector<vec4i>&, const vector<float>&, bool);
-template pair<vector<vec4i>, vector<vec2f>> subdivide_catmullclark(
+template tuple<vector<vec4i>, vector<vec2f>> subdivide_catmullclark(
     const vector<vec4i>&, const vector<vec2f>&, bool);
-template pair<vector<vec4i>, vector<vec3f>> subdivide_catmullclark(
+template tuple<vector<vec4i>, vector<vec3f>> subdivide_catmullclark(
     const vector<vec4i>&, const vector<vec3f>&, bool);
-template pair<vector<vec4i>, vector<vec4f>> subdivide_catmullclark(
+template tuple<vector<vec4i>, vector<vec4f>> subdivide_catmullclark(
     const vector<vec4i>&, const vector<vec4f>&, bool);
 
 // Weld vertices within a threshold. For noe the implementation is O(n^2).
-pair<vector<vec3f>, vector<int>> weld_vertices(
+tuple<vector<vec3f>, vector<int>> weld_vertices(
     const vector<vec3f>& pos, float threshold) {
     auto vid  = vector<int>(pos.size());
     auto wpos = vector<vec3f>();
@@ -899,7 +899,7 @@ pair<vector<vec3f>, vector<int>> weld_vertices(
     }
     return {wpos, vid};
 }
-pair<vector<vec3i>, vector<vec3f>> weld_triangles(
+tuple<vector<vec3i>, vector<vec3f>> weld_triangles(
     const vector<vec3i>& triangles, const vector<vec3f>& pos,
     float threshold) {
     auto vid            = vector<int>();
@@ -914,7 +914,7 @@ pair<vector<vec3i>, vector<vec3f>> weld_triangles(
     }
     return {wtriangles, wpos};
 }
-pair<vector<vec4i>, vector<vec3f>> weld_quads(
+tuple<vector<vec4i>, vector<vec3f>> weld_quads(
     const vector<vec4i>& quads, const vector<vec3f>& pos,
     float threshold) {
     auto vid            = vector<int>();
@@ -3846,7 +3846,7 @@ vec4f eval_elem_tangsp(const shape* shp, int ei) {
     if (!shp->triangles.empty()) {
         auto t    = shp->triangles[ei];
         auto norm = triangle_normal(shp->pos[t.x], shp->pos[t.y], shp->pos[t.z]);
-        auto txty = pair<vec3f, vec3f>();
+        auto txty = tuple<vec3f, vec3f>();
         if (shp->texcoord.empty()) {
             txty = triangle_tangents_fromuv(shp->pos[t.x], shp->pos[t.y],
                 shp->pos[t.z], {0, 0}, {1, 0}, {0, 1});
@@ -3855,7 +3855,7 @@ vec4f eval_elem_tangsp(const shape* shp, int ei) {
                 shp->pos[t.z], shp->texcoord[t.x], shp->texcoord[t.y],
                 shp->texcoord[t.z]);
         }
-        auto tx = txty.first, ty = txty.second;
+        auto tx = get<0>(txty), ty = get<1>(txty);
         tx     = orthonormalize(tx, norm);
         auto s = (dot(cross(norm, tx), ty) < 0) ? -1.0f : 1.0f;
         tangsp = {tx.x, tx.y, tx.z, s};
@@ -4232,14 +4232,14 @@ bsdf eval_bsdf(const instance* ist, int ei, const vec2f& uv) {
 bool is_delta_bsdf(const bsdf& f) { return f.rs == 0 && f.kd == zero3f; }
 
 // Sample a shape based on a distribution.
-pair<int, vec2f> sample_shape(const shape* shp,
+tuple<int, vec2f> sample_shape(const shape* shp,
     const vector<float>& elem_cdf, float re, const vec2f& ruv) {
     // TODO: implement sampling without cdf
     if (elem_cdf.empty()) return {};
     if (!shp->triangles.empty()) {
         return sample_triangles(elem_cdf, re, ruv);
     } else if (!shp->lines.empty()) {
-        return {sample_lines(elem_cdf, re, ruv.x).first, ruv};
+        return {get<0>(sample_lines(elem_cdf, re, ruv.x)), ruv};
     } else if (!shp->pos.empty()) {
         return {sample_points(elem_cdf, re), ruv};
     } else {
@@ -4735,7 +4735,7 @@ vec3f sample_environment(const environment* env,
 vec3f sample_light(const instance* ist, const vector<float>& elem_cdf,
     const vec3f& p, float rel, const vec2f& ruv) {
     auto sample = sample_shape(ist->shp, elem_cdf, rel, ruv);
-    return normalize(eval_pos(ist, sample.first, sample.second) - p);
+    return normalize(eval_pos(ist, get<0>(sample), get<1>(sample)) - p);
 }
 
 // Sample pdf for a light point.
@@ -5950,7 +5950,7 @@ void trace_async_stop(trace_state* state) {
 
 // Trace statistics for last run used for fine tuning implementation.
 // For now returns number of paths and number of rays.
-pair<uint64_t, uint64_t> get_trace_stats() {
+tuple<uint64_t, uint64_t> get_trace_stats() {
     return {_trace_nrays, _trace_npaths};
 }
 void reset_trace_stats() {

--- a/yocto/ygl.cpp
+++ b/yocto/ygl.cpp
@@ -294,9 +294,9 @@ float perlin_turbulence_noise(const vec3f& p, float lacunarity, float gain,
 namespace ygl {
 
 // Compute per-vertex tangents for lines.
-std::vector<vec3f> compute_tangents(
-    const std::vector<vec2i>& lines, const std::vector<vec3f>& pos) {
-    auto norm = std::vector<vec3f>(pos.size(), zero3f);
+vector<vec3f> compute_tangents(
+    const vector<vec2i>& lines, const vector<vec3f>& pos) {
+    auto norm = vector<vec3f>(pos.size(), zero3f);
     for (auto& l : lines) {
         auto n = line_tangent(pos[l.x], pos[l.y]);
         norm[l.x] += n;
@@ -307,9 +307,9 @@ std::vector<vec3f> compute_tangents(
 }
 
 // Compute per-vertex normals for triangles.
-std::vector<vec3f> compute_normals(
-    const std::vector<vec3i>& triangles, const std::vector<vec3f>& pos) {
-    auto norm = std::vector<vec3f>(pos.size(), zero3f);
+vector<vec3f> compute_normals(
+    const vector<vec3i>& triangles, const vector<vec3f>& pos) {
+    auto norm = vector<vec3f>(pos.size(), zero3f);
     for (auto& t : triangles) {
         auto n = triangle_normal(pos[t.x], pos[t.y], pos[t.z]);
         norm[t.x] += n;
@@ -321,9 +321,9 @@ std::vector<vec3f> compute_normals(
 }
 
 // Compute per-vertex normals for quads.
-std::vector<vec3f> compute_normals(
-    const std::vector<vec4i>& quads, const std::vector<vec3f>& pos) {
-    auto norm = std::vector<vec3f>(pos.size(), zero3f);
+vector<vec3f> compute_normals(
+    const vector<vec4i>& quads, const vector<vec3f>& pos) {
+    auto norm = vector<vec3f>(pos.size(), zero3f);
     for (auto q : quads) {
         auto n = quad_normal(pos[q.x], pos[q.y], pos[q.z], pos[q.w]);
         norm[q.x] += n;
@@ -340,11 +340,11 @@ std::vector<vec3f> compute_normals(
 // The first three components are the tangent with respect to the U texcoord.
 // The fourth component is the sign of the tangent wrt the V texcoord.
 // Tangent frame is useful in normal mapping.
-std::vector<vec4f> compute_tangent_space(const std::vector<vec3i>& triangles,
-    const std::vector<vec3f>& pos, const std::vector<vec3f>& norm,
-    const std::vector<vec2f>& texcoord) {
-    auto tangu = std::vector<vec3f>(pos.size(), zero3f);
-    auto tangv = std::vector<vec3f>(pos.size(), zero3f);
+vector<vec4f> compute_tangent_space(const vector<vec3i>& triangles,
+    const vector<vec3f>& pos, const vector<vec3f>& norm,
+    const vector<vec2f>& texcoord) {
+    auto tangu = vector<vec3f>(pos.size(), zero3f);
+    auto tangv = vector<vec3f>(pos.size(), zero3f);
     for (auto t : triangles) {
         auto tutv = triangle_tangents_fromuv(pos[t.x], pos[t.y], pos[t.z],
             texcoord[t.x], texcoord[t.y], texcoord[t.z]);
@@ -354,7 +354,7 @@ std::vector<vec4f> compute_tangent_space(const std::vector<vec3i>& triangles,
     }
     for (auto& t : tangu) t = normalize(t);
     for (auto& t : tangv) t = normalize(t);
-    auto tangsp = std::vector<vec4f>(pos.size(), zero4f);
+    auto tangsp = vector<vec4f>(pos.size(), zero4f);
     for (auto i = 0; i < pos.size(); i++) {
         tangu[i] = orthonormalize(tangu[i], norm[i]);
         auto s   = (dot(cross(norm[i], tangu[i]), tangv[i]) < 0) ? -1.0f : 1.0f;
@@ -364,12 +364,12 @@ std::vector<vec4f> compute_tangent_space(const std::vector<vec3i>& triangles,
 }
 
 // Apply skinning
-std::pair<std::vector<vec3f>, std::vector<vec3f>> compute_skinning(
-    const std::vector<vec3f>& pos, const std::vector<vec3f>& norm,
-    const std::vector<vec4f>& weights, const std::vector<vec4i>& joints,
-    const std::vector<frame3f>& xforms) {
-    auto skinned_pos  = std::vector<vec3f>(pos.size());
-    auto skinned_norm = std::vector<vec3f>(norm.size());
+pair<vector<vec3f>, vector<vec3f>> compute_skinning(
+    const vector<vec3f>& pos, const vector<vec3f>& norm,
+    const vector<vec4f>& weights, const vector<vec4i>& joints,
+    const vector<frame3f>& xforms) {
+    auto skinned_pos  = vector<vec3f>(pos.size());
+    auto skinned_norm = vector<vec3f>(norm.size());
     for (auto i = 0; i < pos.size(); i++) {
         skinned_pos[i] = transform_point(xforms[joints[i].x], pos[i]) *
                              weights[i].x +
@@ -391,12 +391,12 @@ std::pair<std::vector<vec3f>, std::vector<vec3f>> compute_skinning(
 }
 
 // Apply skinning as specified in Khronos glTF
-std::pair<std::vector<vec3f>, std::vector<vec3f>> compute_matrix_skinning(
-    const std::vector<vec3f>& pos, const std::vector<vec3f>& norm,
-    const std::vector<vec4f>& weights, const std::vector<vec4i>& joints,
-    const std::vector<mat4f>& xforms) {
-    auto skinned_pos  = std::vector<vec3f>(pos.size());
-    auto skinned_norm = std::vector<vec3f>(norm.size());
+pair<vector<vec3f>, vector<vec3f>> compute_matrix_skinning(
+    const vector<vec3f>& pos, const vector<vec3f>& norm,
+    const vector<vec4f>& weights, const vector<vec4i>& joints,
+    const vector<mat4f>& xforms) {
+    auto skinned_pos  = vector<vec3f>(pos.size());
+    auto skinned_norm = vector<vec3f>(norm.size());
     for (auto i = 0; i < pos.size(); i++) {
         auto xform = xforms[joints[i].x] * weights[i].x +
                      xforms[joints[i].y] * weights[i].y +
@@ -409,7 +409,7 @@ std::pair<std::vector<vec3f>, std::vector<vec3f>> compute_matrix_skinning(
 }
 
 // Initialize an edge map with elements.
-edge_map make_edge_map(const std::vector<vec3i>& triangles) {
+edge_map make_edge_map(const vector<vec3i>& triangles) {
     auto emap = edge_map{};
     for (auto& t : triangles) {
         insert_edge(emap, {t.x, t.y});
@@ -418,7 +418,7 @@ edge_map make_edge_map(const std::vector<vec3i>& triangles) {
     }
     return emap;
 }
-edge_map make_edge_map(const std::vector<vec4i>& quads) {
+edge_map make_edge_map(const vector<vec4i>& quads) {
     auto emap = edge_map{};
     for (auto& q : quads) {
         insert_edge(emap, {q.x, q.y});
@@ -452,21 +452,21 @@ int get_edge_count(const edge_map& emap, const vec2i& e) {
     return emap.at(es).y;
 }
 // Get a list of edges, boundary edges, boundary vertices
-std::vector<vec2i> get_edges(const edge_map& emap) {
-    auto edges = std::vector<vec2i>(emap.size());
+vector<vec2i> get_edges(const edge_map& emap) {
+    auto edges = vector<vec2i>(emap.size());
     for (auto& kv : emap) edges[kv.second.x] = kv.first;
     return edges;
 }
-std::vector<vec2i> get_boundary(const edge_map& emap) {
-    auto boundary = std::vector<vec2i>();
+vector<vec2i> get_boundary(const edge_map& emap) {
+    auto boundary = vector<vec2i>();
     for (auto& kv : emap)
         if (kv.second.y < 2) boundary.push_back(kv.first);
     return boundary;
 }
 
 // Convert quads to triangles
-std::vector<vec3i> convert_quads_to_triangles(const std::vector<vec4i>& quads) {
-    auto triangles = std::vector<vec3i>();
+vector<vec3i> convert_quads_to_triangles(const vector<vec4i>& quads) {
+    auto triangles = vector<vec3i>();
     triangles.reserve(quads.size() * 2);
     for (auto& q : quads) {
         triangles.push_back({q.x, q.y, q.w});
@@ -477,9 +477,9 @@ std::vector<vec3i> convert_quads_to_triangles(const std::vector<vec4i>& quads) {
 
 // Convert quads to triangles with a diamond-like topology.
 // Quads have to be consecutive one row after another.
-std::vector<vec3i> convert_quads_to_triangles(
-    const std::vector<vec4i>& quads, int row_length) {
-    auto triangles = std::vector<vec3i>();
+vector<vec3i> convert_quads_to_triangles(
+    const vector<vec4i>& quads, int row_length) {
+    auto triangles = vector<vec3i>();
     triangles.reserve(quads.size() * 2);
     for (auto& q : quads) {
         triangles.push_back({q.x, q.y, q.w});
@@ -506,8 +506,8 @@ std::vector<vec3i> convert_quads_to_triangles(
 }
 
 // Convert beziers to lines using 3 lines for each bezier.
-std::vector<vec2i> convert_bezier_to_lines(const std::vector<vec4i>& beziers) {
-    auto lines = std::vector<vec2i>();
+vector<vec2i> convert_bezier_to_lines(const vector<vec4i>& beziers) {
+    auto lines = vector<vec2i>();
     lines.reserve(beziers.size() * 3);
     for (auto b : beziers) {
         lines.push_back({b.x, b.y});
@@ -519,17 +519,17 @@ std::vector<vec2i> convert_bezier_to_lines(const std::vector<vec4i>& beziers) {
 
 // Convert face varying data to single primitives. Returns the quads indices
 // and filled vectors for pos, norm and texcoord.
-void convert_face_varying(std::vector<vec4i>& qquads, std::vector<vec3f>& qpos,
-    std::vector<vec3f>& qnorm, std::vector<vec2f>& qtexcoord,
-    std::vector<vec4f>& qcolor, const std::vector<vec4i>& quads_pos,
-    const std::vector<vec4i>& quads_norm,
-    const std::vector<vec4i>& quads_texcoord,
-    const std::vector<vec4i>& quads_color, const std::vector<vec3f>& pos,
-    const std::vector<vec3f>& norm, const std::vector<vec2f>& texcoord,
-    const std::vector<vec4f>& color) {
+void convert_face_varying(vector<vec4i>& qquads, vector<vec3f>& qpos,
+    vector<vec3f>& qnorm, vector<vec2f>& qtexcoord,
+    vector<vec4f>& qcolor, const vector<vec4i>& quads_pos,
+    const vector<vec4i>& quads_norm,
+    const vector<vec4i>& quads_texcoord,
+    const vector<vec4i>& quads_color, const vector<vec3f>& pos,
+    const vector<vec3f>& norm, const vector<vec2f>& texcoord,
+    const vector<vec4f>& color) {
     // make faces unique
-    std::unordered_map<vec4i, int> vert_map;
-    qquads = std::vector<vec4i>(quads_pos.size());
+    unordered_map<vec4i, int> vert_map;
+    qquads = vector<vec4i>(quads_pos.size());
     for (auto fid = 0; fid < quads_pos.size(); fid++) {
         for (auto c = 0; c < 4; c++) {
             auto v = vec4i{
@@ -571,19 +571,19 @@ void convert_face_varying(std::vector<vec4i>& qquads, std::vector<vec3f>& qpos,
 
 // Subdivide lines.
 template <typename T>
-std::pair<std::vector<vec2i>, std::vector<T>> subdivide_lines(
-    const std::vector<vec2i>& lines, const std::vector<T>& vert) {
+pair<vector<vec2i>, vector<T>> subdivide_lines(
+    const vector<vec2i>& lines, const vector<T>& vert) {
     auto nverts = (int)vert.size();
     auto nlines = (int)lines.size();
     // create vertices
-    auto tvert = std::vector<T>(nverts + nlines);
+    auto tvert = vector<T>(nverts + nlines);
     for (auto i = 0; i < nverts; i++) tvert[i] = vert[i];
     for (auto i = 0; i < nlines; i++) {
         auto l            = lines[i];
         tvert[nverts + i] = (vert[l.x] + vert[l.y]) / 2;
     }
     // create lines
-    auto tlines = std::vector<vec2i>(nlines * 2);
+    auto tlines = vector<vec2i>(nlines * 2);
     for (auto i = 0; i < nlines; i++) {
         auto l            = lines[i];
         tlines[i * 2 + 0] = {l.x, nverts + i};
@@ -593,19 +593,19 @@ std::pair<std::vector<vec2i>, std::vector<T>> subdivide_lines(
     return {tlines, tvert};
 }
 
-template std::pair<std::vector<vec2i>, std::vector<float>> subdivide_lines(
-    const std::vector<vec2i>&, const std::vector<float>&);
-template std::pair<std::vector<vec2i>, std::vector<vec2f>> subdivide_lines(
-    const std::vector<vec2i>&, const std::vector<vec2f>&);
-template std::pair<std::vector<vec2i>, std::vector<vec3f>> subdivide_lines(
-    const std::vector<vec2i>&, const std::vector<vec3f>&);
-template std::pair<std::vector<vec2i>, std::vector<vec4f>> subdivide_lines(
-    const std::vector<vec2i>&, const std::vector<vec4f>&);
+template pair<vector<vec2i>, vector<float>> subdivide_lines(
+    const vector<vec2i>&, const vector<float>&);
+template pair<vector<vec2i>, vector<vec2f>> subdivide_lines(
+    const vector<vec2i>&, const vector<vec2f>&);
+template pair<vector<vec2i>, vector<vec3f>> subdivide_lines(
+    const vector<vec2i>&, const vector<vec3f>&);
+template pair<vector<vec2i>, vector<vec4f>> subdivide_lines(
+    const vector<vec2i>&, const vector<vec4f>&);
 
 // Subdivide triangle.
 template <typename T>
-std::pair<std::vector<vec3i>, std::vector<T>> subdivide_triangles(
-    const std::vector<vec3i>& triangles, const std::vector<T>& vert) {
+pair<vector<vec3i>, vector<T>> subdivide_triangles(
+    const vector<vec3i>& triangles, const vector<T>& vert) {
     // get edges
     auto emap  = make_edge_map(triangles);
     auto edges = get_edges(emap);
@@ -614,14 +614,14 @@ std::pair<std::vector<vec3i>, std::vector<T>> subdivide_triangles(
     auto nedges = (int)edges.size();
     auto nfaces = (int)triangles.size();
     // create vertices
-    auto tvert = std::vector<T>(nverts + nedges);
+    auto tvert = vector<T>(nverts + nedges);
     for (auto i = 0; i < nverts; i++) tvert[i] = vert[i];
     for (auto i = 0; i < nedges; i++) {
         auto e            = edges[i];
         tvert[nverts + i] = (vert[e.x] + vert[e.y]) / 2;
     }
     // create triangles
-    auto ttriangles = std::vector<vec3i>(nfaces * 4);
+    auto ttriangles = vector<vec3i>(nfaces * 4);
     for (auto i = 0; i < nfaces; i++) {
         auto t                = triangles[i];
         ttriangles[i * 4 + 0] = {t.x, nverts + get_edge_index(emap, {t.x, t.y}),
@@ -638,19 +638,19 @@ std::pair<std::vector<vec3i>, std::vector<T>> subdivide_triangles(
     return {ttriangles, tvert};
 }
 
-template std::pair<std::vector<vec3i>, std::vector<float>> subdivide_triangles(
-    const std::vector<vec3i>&, const std::vector<float>&);
-template std::pair<std::vector<vec3i>, std::vector<vec2f>> subdivide_triangles(
-    const std::vector<vec3i>&, const std::vector<vec2f>&);
-template std::pair<std::vector<vec3i>, std::vector<vec3f>> subdivide_triangles(
-    const std::vector<vec3i>&, const std::vector<vec3f>&);
-template std::pair<std::vector<vec3i>, std::vector<vec4f>> subdivide_triangles(
-    const std::vector<vec3i>&, const std::vector<vec4f>&);
+template pair<vector<vec3i>, vector<float>> subdivide_triangles(
+    const vector<vec3i>&, const vector<float>&);
+template pair<vector<vec3i>, vector<vec2f>> subdivide_triangles(
+    const vector<vec3i>&, const vector<vec2f>&);
+template pair<vector<vec3i>, vector<vec3f>> subdivide_triangles(
+    const vector<vec3i>&, const vector<vec3f>&);
+template pair<vector<vec3i>, vector<vec4f>> subdivide_triangles(
+    const vector<vec3i>&, const vector<vec4f>&);
 
 // Subdivide quads.
 template <typename T>
-std::pair<std::vector<vec4i>, std::vector<T>> subdivide_quads(
-    const std::vector<vec4i>& quads, const std::vector<T>& vert) {
+pair<vector<vec4i>, vector<T>> subdivide_quads(
+    const vector<vec4i>& quads, const vector<T>& vert) {
     // get edges
     auto emap  = make_edge_map(quads);
     auto edges = get_edges(emap);
@@ -659,7 +659,7 @@ std::pair<std::vector<vec4i>, std::vector<T>> subdivide_quads(
     auto nedges = (int)edges.size();
     auto nfaces = (int)quads.size();
     // create vertices
-    auto tvert = std::vector<T>(nverts + nedges + nfaces);
+    auto tvert = vector<T>(nverts + nedges + nfaces);
     for (auto i = 0; i < nverts; i++) tvert[i] = vert[i];
     for (auto i = 0; i < nedges; i++) {
         auto e            = edges[i];
@@ -676,7 +676,7 @@ std::pair<std::vector<vec4i>, std::vector<T>> subdivide_quads(
         }
     }
     // create quads
-    auto tquads = std::vector<vec4i>(nfaces * 4);  // conservative allocation
+    auto tquads = vector<vec4i>(nfaces * 4);  // conservative allocation
     auto qi     = 0;
     for (auto i = 0; i < nfaces; i++) {
         auto q = quads[i];
@@ -703,22 +703,22 @@ std::pair<std::vector<vec4i>, std::vector<T>> subdivide_quads(
     return {tquads, tvert};
 }
 
-template std::pair<std::vector<vec4i>, std::vector<float>> subdivide_quads(
-    const std::vector<vec4i>&, const std::vector<float>&);
-template std::pair<std::vector<vec4i>, std::vector<vec2f>> subdivide_quads(
-    const std::vector<vec4i>&, const std::vector<vec2f>&);
-template std::pair<std::vector<vec4i>, std::vector<vec3f>> subdivide_quads(
-    const std::vector<vec4i>&, const std::vector<vec3f>&);
-template std::pair<std::vector<vec4i>, std::vector<vec4f>> subdivide_quads(
-    const std::vector<vec4i>&, const std::vector<vec4f>&);
+template pair<vector<vec4i>, vector<float>> subdivide_quads(
+    const vector<vec4i>&, const vector<float>&);
+template pair<vector<vec4i>, vector<vec2f>> subdivide_quads(
+    const vector<vec4i>&, const vector<vec2f>&);
+template pair<vector<vec4i>, vector<vec3f>> subdivide_quads(
+    const vector<vec4i>&, const vector<vec3f>&);
+template pair<vector<vec4i>, vector<vec4f>> subdivide_quads(
+    const vector<vec4i>&, const vector<vec4f>&);
 
 // Subdivide beziers.
 template <typename T>
-std::pair<std::vector<vec4i>, std::vector<T>> subdivide_beziers(
-    const std::vector<vec4i>& beziers, const std::vector<T>& vert) {
-    auto vmap     = std::unordered_map<int, int>();
-    auto tvert    = std::vector<T>();
-    auto tbeziers = std::vector<vec4i>();
+pair<vector<vec4i>, vector<T>> subdivide_beziers(
+    const vector<vec4i>& beziers, const vector<T>& vert) {
+    auto vmap     = unordered_map<int, int>();
+    auto tvert    = vector<T>();
+    auto tbeziers = vector<vec4i>();
     for (auto b : beziers) {
         if (vmap.find(b.x) == vmap.end()) {
             vmap[b.x] = (int)tvert.size();
@@ -742,19 +742,19 @@ std::pair<std::vector<vec4i>, std::vector<T>> subdivide_beziers(
     return {tbeziers, tvert};
 }
 
-template std::pair<std::vector<vec4i>, std::vector<float>> subdivide_beziers(
-    const std::vector<vec4i>&, const std::vector<float>&);
-template std::pair<std::vector<vec4i>, std::vector<vec2f>> subdivide_beziers(
-    const std::vector<vec4i>&, const std::vector<vec2f>&);
-template std::pair<std::vector<vec4i>, std::vector<vec3f>> subdivide_beziers(
-    const std::vector<vec4i>&, const std::vector<vec3f>&);
-template std::pair<std::vector<vec4i>, std::vector<vec4f>> subdivide_beziers(
-    const std::vector<vec4i>&, const std::vector<vec4f>&);
+template pair<vector<vec4i>, vector<float>> subdivide_beziers(
+    const vector<vec4i>&, const vector<float>&);
+template pair<vector<vec4i>, vector<vec2f>> subdivide_beziers(
+    const vector<vec4i>&, const vector<vec2f>&);
+template pair<vector<vec4i>, vector<vec3f>> subdivide_beziers(
+    const vector<vec4i>&, const vector<vec3f>&);
+template pair<vector<vec4i>, vector<vec4f>> subdivide_beziers(
+    const vector<vec4i>&, const vector<vec4f>&);
 
 // Subdivide catmullclark.
 template <typename T>
-std::pair<std::vector<vec4i>, std::vector<T>> subdivide_catmullclark(
-    const std::vector<vec4i>& quads, const std::vector<T>& vert,
+pair<vector<vec4i>, vector<T>> subdivide_catmullclark(
+    const vector<vec4i>& quads, const vector<T>& vert,
     bool lock_boundary) {
     // get edges
     auto emap     = make_edge_map(quads);
@@ -768,7 +768,7 @@ std::pair<std::vector<vec4i>, std::vector<T>> subdivide_catmullclark(
 
     // split elements ------------------------------------
     // create vertices
-    auto tvert = std::vector<T>(nverts + nedges + nfaces);
+    auto tvert = vector<T>(nverts + nedges + nfaces);
     for (auto i = 0; i < nverts; i++) tvert[i] = vert[i];
     for (auto i = 0; i < nedges; i++) {
         auto e            = edges[i];
@@ -785,7 +785,7 @@ std::pair<std::vector<vec4i>, std::vector<T>> subdivide_catmullclark(
         }
     }
     // create quads
-    auto tquads = std::vector<vec4i>(nfaces * 4);  // conservative allocation
+    auto tquads = vector<vec4i>(nfaces * 4);  // conservative allocation
     auto qi     = 0;
     for (auto i = 0; i < nfaces; i++) {
         auto q = quads[i];
@@ -810,7 +810,7 @@ std::pair<std::vector<vec4i>, std::vector<T>> subdivide_catmullclark(
     tquads.resize(qi);
 
     // split boundary
-    auto tboundary = std::vector<vec2i>(nboundary * 2);
+    auto tboundary = vector<vec2i>(nboundary * 2);
     for (auto i = 0; i < nboundary; i++) {
         auto e = boundary[i];
         tboundary.push_back({e.x, nverts + get_edge_index(emap, e)});
@@ -818,8 +818,8 @@ std::pair<std::vector<vec4i>, std::vector<T>> subdivide_catmullclark(
     }
 
     // setup creases -----------------------------------
-    auto tcrease_edges = std::vector<vec2i>();
-    auto tcrease_verts = std::vector<int>();
+    auto tcrease_edges = vector<vec2i>();
+    auto tcrease_verts = vector<int>();
     if (lock_boundary) {
         for (auto& b : tboundary) {
             tcrease_verts.push_back(b.x);
@@ -830,15 +830,15 @@ std::pair<std::vector<vec4i>, std::vector<T>> subdivide_catmullclark(
     }
 
     // define vertex valence ---------------------------
-    auto tvert_val = std::vector<int>(tvert.size(), 2);
+    auto tvert_val = vector<int>(tvert.size(), 2);
     for (auto& e : tboundary) {
         tvert_val[e.x] = (lock_boundary) ? 0 : 1;
         tvert_val[e.y] = (lock_boundary) ? 0 : 1;
     }
 
     // averaging pass ----------------------------------
-    auto avert  = std::vector<T>(tvert.size(), T());
-    auto acount = std::vector<int>(tvert.size(), 0);
+    auto avert  = vector<T>(tvert.size(), T());
+    auto acount = vector<int>(tvert.size(), 0);
     for (auto p : tcrease_verts) {
         if (tvert_val[p] != 0) continue;
         avert[p] += tvert[p];
@@ -873,20 +873,20 @@ std::pair<std::vector<vec4i>, std::vector<T>> subdivide_catmullclark(
     return {tquads, tvert};
 }
 
-template std::pair<std::vector<vec4i>, std::vector<float>> subdivide_catmullclark(
-    const std::vector<vec4i>&, const std::vector<float>&, bool);
-template std::pair<std::vector<vec4i>, std::vector<vec2f>> subdivide_catmullclark(
-    const std::vector<vec4i>&, const std::vector<vec2f>&, bool);
-template std::pair<std::vector<vec4i>, std::vector<vec3f>> subdivide_catmullclark(
-    const std::vector<vec4i>&, const std::vector<vec3f>&, bool);
-template std::pair<std::vector<vec4i>, std::vector<vec4f>> subdivide_catmullclark(
-    const std::vector<vec4i>&, const std::vector<vec4f>&, bool);
+template pair<vector<vec4i>, vector<float>> subdivide_catmullclark(
+    const vector<vec4i>&, const vector<float>&, bool);
+template pair<vector<vec4i>, vector<vec2f>> subdivide_catmullclark(
+    const vector<vec4i>&, const vector<vec2f>&, bool);
+template pair<vector<vec4i>, vector<vec3f>> subdivide_catmullclark(
+    const vector<vec4i>&, const vector<vec3f>&, bool);
+template pair<vector<vec4i>, vector<vec4f>> subdivide_catmullclark(
+    const vector<vec4i>&, const vector<vec4f>&, bool);
 
 // Weld vertices within a threshold. For noe the implementation is O(n^2).
-std::pair<std::vector<vec3f>, std::vector<int>> weld_vertices(
-    const std::vector<vec3f>& pos, float threshold) {
-    auto vid  = std::vector<int>(pos.size());
-    auto wpos = std::vector<vec3f>();
+pair<vector<vec3f>, vector<int>> weld_vertices(
+    const vector<vec3f>& pos, float threshold) {
+    auto vid  = vector<int>(pos.size());
+    auto wpos = vector<vec3f>();
     for (auto i = 0; i < pos.size(); i++) {
         vid[i] = (int)wpos.size();
         for (auto j = 0; j < wpos.size(); j++) {
@@ -899,13 +899,13 @@ std::pair<std::vector<vec3f>, std::vector<int>> weld_vertices(
     }
     return {wpos, vid};
 }
-std::pair<std::vector<vec3i>, std::vector<vec3f>> weld_triangles(
-    const std::vector<vec3i>& triangles, const std::vector<vec3f>& pos,
+pair<vector<vec3i>, vector<vec3f>> weld_triangles(
+    const vector<vec3i>& triangles, const vector<vec3f>& pos,
     float threshold) {
-    auto vid            = std::vector<int>();
-    auto wpos           = std::vector<vec3f>();
+    auto vid            = vector<int>();
+    auto wpos           = vector<vec3f>();
     std::tie(wpos, vid) = weld_vertices(pos, threshold);
-    auto wtriangles     = std::vector<vec3i>();
+    auto wtriangles     = vector<vec3i>();
     for (auto t : triangles) {
         t.x = vid[t.x];
         t.y = vid[t.y];
@@ -914,13 +914,13 @@ std::pair<std::vector<vec3i>, std::vector<vec3f>> weld_triangles(
     }
     return {wtriangles, wpos};
 }
-std::pair<std::vector<vec4i>, std::vector<vec3f>> weld_quads(
-    const std::vector<vec4i>& quads, const std::vector<vec3f>& pos,
+pair<vector<vec4i>, vector<vec3f>> weld_quads(
+    const vector<vec4i>& quads, const vector<vec3f>& pos,
     float threshold) {
-    auto vid            = std::vector<int>();
-    auto wpos           = std::vector<vec3f>();
+    auto vid            = vector<int>();
+    auto wpos           = vector<vec3f>();
     std::tie(wpos, vid) = weld_vertices(pos, threshold);
-    auto wquads         = std::vector<vec4i>();
+    auto wquads         = vector<vec4i>();
     for (auto q : quads) {
         q.x = vid[q.x];
         q.y = vid[q.y];
@@ -934,13 +934,13 @@ std::pair<std::vector<vec4i>, std::vector<vec3f>> weld_quads(
 // Samples a set of points over a triangle mesh uniformly. The rng function
 // takes the point index and returns vec3f numbers uniform directibuted in
 // [0,1]^3. unorm and texcoord are optional.
-std::tuple<std::vector<vec3f>, std::vector<vec3f>, std::vector<vec2f>>
-sample_triangles_points(const std::vector<vec3i>& triangles,
-    const std::vector<vec3f>& pos, const std::vector<vec3f>& norm,
-    const std::vector<vec2f>& texcoord, int npoints, int seed) {
-    auto sampled_pos      = std::vector<vec3f>(npoints);
-    auto sampled_norm     = std::vector<vec3f>(npoints);
-    auto sampled_texcoord = std::vector<vec2f>(npoints);
+std::tuple<vector<vec3f>, vector<vec3f>, vector<vec2f>>
+sample_triangles_points(const vector<vec3i>& triangles,
+    const vector<vec3f>& pos, const vector<vec3f>& norm,
+    const vector<vec2f>& texcoord, int npoints, int seed) {
+    auto sampled_pos      = vector<vec3f>(npoints);
+    auto sampled_norm     = vector<vec3f>(npoints);
+    auto sampled_texcoord = vector<vec2f>(npoints);
     auto cdf              = sample_triangles_cdf(triangles, pos);
     auto rng              = make_rng(seed);
     for (auto i = 0; i < npoints; i++) {
@@ -1316,7 +1316,7 @@ struct bvh_prim {
 // or initializing it as a leaf. When splitting, the heuristic heuristic is
 // used and nodes added sequentially in the preallocated nodes array and
 // the number of nodes nnodes is updated.
-int make_bvh_node(std::vector<bvh_node>& nodes, std::vector<bvh_prim>& prims,
+int make_bvh_node(vector<bvh_node>& nodes, vector<bvh_prim>& prims,
     int start, int end, bool high_quality) {
     // add a new node
     auto nodeid = (int)nodes.size();
@@ -1450,7 +1450,7 @@ int make_bvh_node(std::vector<bvh_node>& nodes, std::vector<bvh_prim>& prims,
 // Build a BVH from a set of primitives.
 void build_bvh(bvh_tree* bvh, bool high_quality) {
     // get the number of primitives and the primitive type
-    auto prims = std::vector<bvh_prim>();
+    auto prims = vector<bvh_prim>();
     if (!bvh->points.empty()) {
         for (auto& p : bvh->points) {
             prims.push_back({point_bbox(bvh->pos[p], bvh->radius[p])});
@@ -1852,7 +1852,7 @@ bool overlap_bvh(const bvh_tree* bvh, const vec3f& pos, float max_dist,
     // Finds the overlap between BVH leaf nodes.
     template <typename OverlapElem>
     void overlap_bvh_elems(const bvh_tree* bvh1, const bvh_tree* bvh2,
-                           bool skip_duplicates, bool skip_self, std::vector<vec2i>& overlaps,
+                           bool skip_duplicates, bool skip_self, vector<vec2i>& overlaps,
                            const OverlapElem& overlap_elems) {
         // node stack
         vec2i node_stack[128];
@@ -1970,7 +1970,7 @@ make_shape_data make_floor(const vec2i& steps, const vec2f& size,
 // Make a stack of quads
 make_shape_data make_quad_stack(const vec3i& steps, const vec3f& size,
     const vec2f& uvsize, bool as_triangles) {
-    auto qshps = std::vector<make_shape_data>(steps.z + 1);
+    auto qshps = vector<make_shape_data>(steps.z + 1);
     for (auto i = 0; i <= steps.z; i++) {
         qshps[i] = make_quad(
             {steps.x, steps.y}, {size.x, size.y}, uvsize, as_triangles);
@@ -1983,7 +1983,7 @@ make_shape_data make_quad_stack(const vec3i& steps, const vec3f& size,
 // Make a cube.
 make_shape_data make_cube(const vec3i& steps, const vec3f& size,
     const vec3f& uvsize, bool as_triangles) {
-    auto qshps = std::vector<make_shape_data>(6);
+    auto qshps = vector<make_shape_data>(6);
     // + z
     qshps[0] = make_quad({steps.x, steps.y}, {size.x, size.y},
         {uvsize.x, uvsize.y}, as_triangles);
@@ -2172,7 +2172,7 @@ make_shape_data make_cylinder_side(const vec2i& steps, const vec2f& size,
 // Make a cylinder.
 make_shape_data make_cylinder(const vec3i& steps, const vec2f& size,
     const vec3f& uvsize, bool as_triangles) {
-    auto qshps = std::vector<make_shape_data>(3);
+    auto qshps = vector<make_shape_data>(3);
     // side
     qshps[0] = make_cylinder_side({steps.x, steps.y}, {size.x, size.y},
         {uvsize.x, uvsize.y}, as_triangles);
@@ -2224,10 +2224,10 @@ make_shape_data make_geodesic_sphere(
     // https://stackoverflow.com/questions/17705621/algorithm-for-a-geodesic-sphere
     const float X         = 0.525731112119133606f;
     const float Z         = 0.850650808352039932f;
-    static auto pos       = std::vector<vec3f>{{-X, 0.0, Z}, {X, 0.0, Z},
+    static auto pos       = vector<vec3f>{{-X, 0.0, Z}, {X, 0.0, Z},
         {-X, 0.0, -Z}, {X, 0.0, -Z}, {0.0, Z, X}, {0.0, Z, -X}, {0.0, -Z, X},
         {0.0, -Z, -X}, {Z, X, 0.0}, {-Z, X, 0.0}, {Z, -X, 0.0}, {-Z, -X, 0.0}};
-    static auto triangles = std::vector<vec3i>{{0, 1, 4}, {0, 4, 9}, {9, 4, 5},
+    static auto triangles = vector<vec3i>{{0, 1, 4}, {0, 4, 9}, {9, 4, 5},
         {4, 8, 5}, {4, 1, 8}, {8, 1, 10}, {8, 10, 3}, {5, 8, 3}, {5, 3, 2},
         {2, 3, 7}, {7, 3, 10}, {7, 10, 6}, {7, 6, 11}, {11, 6, 0}, {0, 6, 1},
         {6, 10, 1}, {9, 11, 0}, {9, 2, 11}, {9, 5, 2}, {7, 11, 2}};
@@ -2262,7 +2262,7 @@ make_fvshape_data make_fvcube(
 // Make a suzanne monkey model for testing. Note that some quads are
 // degenerate.
 make_shape_data make_suzanne(float size, bool as_triangles) {
-    static auto suzanne_pos = std::vector<vec3f>{{0.4375, 0.1640625, 0.765625},
+    static auto suzanne_pos = vector<vec3f>{{0.4375, 0.1640625, 0.765625},
         {-0.4375, 0.1640625, 0.765625}, {0.5, 0.09375, 0.6875},
         {-0.5, 0.09375, 0.6875}, {0.546875, 0.0546875, 0.578125},
         {-0.546875, 0.0546875, 0.578125}, {0.3515625, -0.0234375, 0.6171875},
@@ -2517,7 +2517,7 @@ make_shape_data make_suzanne(float size, bool as_triangles) {
         {-1.0390625, -0.0859375, -0.4921875}, {0.7890625, -0.125, -0.328125},
         {-0.7890625, -0.125, -0.328125}, {0.859375, 0.3828125, -0.3828125},
         {-0.859375, 0.3828125, -0.3828125}};
-    static auto suzanne_triangles = std::vector<vec3i>{{60, 64, 48},
+    static auto suzanne_triangles = vector<vec3i>{{60, 64, 48},
         {49, 65, 61}, {62, 64, 60}, {61, 65, 63}, {60, 58, 62}, {63, 59, 61},
         {60, 56, 58}, {59, 57, 61}, {60, 54, 56}, {57, 55, 61}, {60, 52, 54},
         {55, 53, 61}, {60, 50, 52}, {53, 51, 61}, {60, 48, 50}, {51, 49, 61},
@@ -2525,7 +2525,7 @@ make_shape_data make_suzanne(float size, bool as_triangles) {
         {341, 347, 383}, {384, 348, 342}, {299, 345, 343}, {344, 346, 300},
         {323, 379, 351}, {352, 380, 324}, {441, 443, 445}, {446, 444, 442},
         {463, 491, 465}, {466, 492, 464}, {495, 497, 499}, {500, 498, 496}};
-    static auto suzanne_quads     = std::vector<vec4i>{{46, 0, 2, 44},
+    static auto suzanne_quads     = vector<vec4i>{{46, 0, 2, 44},
         {3, 1, 47, 45}, {44, 2, 4, 42}, {5, 3, 45, 43}, {2, 8, 6, 4},
         {7, 9, 3, 5}, {0, 10, 8, 2}, {9, 11, 1, 3}, {10, 12, 14, 8},
         {15, 13, 11, 9}, {8, 14, 16, 6}, {17, 15, 9, 7}, {14, 20, 18, 16},
@@ -2696,12 +2696,12 @@ make_shape_data make_suzanne(float size, bool as_triangles) {
 
 // Watertight cube
 make_shape_data make_cube(const vec3f& size, bool as_triangles) {
-    static auto cube_pos     = std::vector<vec3f>{{-1, -1, -1}, {-1, +1, -1},
+    static auto cube_pos     = vector<vec3f>{{-1, -1, -1}, {-1, +1, -1},
         {+1, +1, -1}, {+1, -1, -1}, {-1, -1, +1}, {-1, +1, +1}, {+1, +1, +1},
         {+1, -1, +1}};
-    static auto cube_quads   = std::vector<vec4i>{{0, 1, 2, 3}, {7, 6, 5, 4},
+    static auto cube_quads   = vector<vec4i>{{0, 1, 2, 3}, {7, 6, 5, 4},
         {4, 5, 1, 0}, {6, 7, 3, 2}, {2, 1, 5, 6}, {0, 3, 7, 4}};
-    static auto cube_quad_uv = std::vector<vec2f>{
+    static auto cube_quad_uv = vector<vec2f>{
         {0, 0}, {1, 0}, {1, 1}, {0, 1}};
     auto shp = make_shape_data();
     shp.pos  = cube_pos;
@@ -2797,10 +2797,10 @@ make_shape_data make_point(float point_radius) {
 make_shape_data make_bezier_circle(float size) {
     // constant from http://spencermortensen.com/articles/bezier-circle/
     const auto  c          = 0.551915024494f;
-    static auto circle_pos = std::vector<vec3f>{{1, 0, 0}, {1, c, 0}, {c, 1, 0},
+    static auto circle_pos = vector<vec3f>{{1, 0, 0}, {1, c, 0}, {c, 1, 0},
         {0, 1, 0}, {-c, 1, 0}, {-1, c, 0}, {-1, 0, 0}, {-1, -c, 0}, {-c, -1, 0},
         {0, -1, 0}, {c, -1, 0}, {1, -c, 0}};
-    static auto circle_beziers = std::vector<vec4i>{
+    static auto circle_beziers = vector<vec4i>{
         {0, 1, 2, 3}, {3, 4, 5, 6}, {6, 7, 8, 9}, {9, 10, 11, 0}};
     auto shp    = make_shape_data();
     shp.pos     = circle_pos;
@@ -2810,21 +2810,21 @@ make_shape_data make_bezier_circle(float size) {
 
 // Make a hair ball around a shape
 make_shape_data make_hair(const vec2i& steps,
-    const std::vector<vec3i>& striangles, const std::vector<vec3f>& spos,
-    const std::vector<vec3f>& snorm, const std::vector<vec2f>& stexcoord,
+    const vector<vec3i>& striangles, const vector<vec3f>& spos,
+    const vector<vec3f>& snorm, const vector<vec2f>& stexcoord,
     const vec2f& len, const vec2f& rad, const vec2f& noise, const vec2f& clump,
     const vec2f& rotation, int seed) {
-    std::vector<vec3f> bpos;
-    std::vector<vec3f> bnorm;
-    std::vector<vec2f> btexcoord;
+    vector<vec3f> bpos;
+    vector<vec3f> bnorm;
+    vector<vec2f> btexcoord;
     std::tie(bpos, bnorm, btexcoord) = sample_triangles_points(
         striangles, spos, snorm, stexcoord, steps.y, seed);
 
     auto rng  = make_rng(seed, 3);
-    auto blen = std::vector<float>(bpos.size());
+    auto blen = vector<float>(bpos.size());
     for (auto& l : blen) l = lerp(len.x, len.y, rand1f(rng));
 
-    auto cidx = std::vector<int>();
+    auto cidx = vector<int>();
     if (clump.x > 0) {
         for (auto bidx = 0; bidx < bpos.size(); bidx++) {
             cidx.push_back(0);
@@ -2869,7 +2869,7 @@ make_shape_data make_hair(const vec2i& steps,
 }
 
 // Helper to concatenated shape data for non-facevarying shapes.
-make_shape_data merge_shape_data(const std::vector<make_shape_data>& shapes) {
+make_shape_data merge_shape_data(const vector<make_shape_data>& shapes) {
     auto shp = make_shape_data();
     for (auto& sshp : shapes) {
         auto nverts = (int)shp.pos.size();
@@ -3460,7 +3460,7 @@ bbox3f compute_bbox(const shape* shp) {
 
 // Updates the scene and scene's instances bounding boxes
 bbox3f compute_bbox(const scene* scn) {
-    auto sbbox = std::unordered_map<shape*, bbox3f>();
+    auto sbbox = unordered_map<shape*, bbox3f>();
     for (auto shp : scn->shapes) sbbox[shp] = compute_bbox(shp);
     auto bbox = invalid_bbox3f;
     for (auto ist : scn->instances)
@@ -3484,7 +3484,7 @@ void tesselate_subdiv(const subdiv* sbd, shape* shp) {
         std::tie(quads_color, color) = subdivide_catmullclark(
             quads_color, color);
     }
-    auto norm = std::vector<vec3f>();
+    auto norm = vector<vec3f>();
     if (sbd->compute_normals) norm = compute_normals(quads_pos, pos);
     auto quads = quads_pos;
     convert_face_varying(quads, shp->pos, shp->norm, shp->texcoord, shp->color,
@@ -3501,7 +3501,7 @@ void tesselate_subdivs(scene* scn) {
 
 // Update animation transforms
 void update_transforms(
-    animation* anm, float time, const std::string& anim_group) {
+    animation* anm, float time, const string& anim_group) {
     if (anim_group != "" && anim_group != anm->group) return;
 
     if (!anm->translation.empty()) {
@@ -3563,7 +3563,7 @@ void update_transforms(node* nde, const frame3f& parent = identity_frame3f) {
 }
 
 // Update node transforms
-void update_transforms(scene* scn, float time, const std::string& anim_group) {
+void update_transforms(scene* scn, float time, const string& anim_group) {
     for (auto& agr : scn->animations) update_transforms(agr, time, anim_group);
     for (auto& nde : scn->nodes) nde->children.clear();
     for (auto& nde : scn->nodes)
@@ -3573,7 +3573,7 @@ void update_transforms(scene* scn, float time, const std::string& anim_group) {
 }
 
 // Compute animation range
-vec2f compute_animation_range(const scene* scn, const std::string& anim_group) {
+vec2f compute_animation_range(const scene* scn, const string& anim_group) {
     if (scn->animations.empty()) return zero2f;
     auto range = vec2f{+maxf, -maxf};
     for (auto anm : scn->animations) {
@@ -3586,7 +3586,7 @@ vec2f compute_animation_range(const scene* scn, const std::string& anim_group) {
 }
 
 // Generate a distribution for sampling a shape uniformly based on area/length.
-std::vector<float> compute_shape_cdf(const shape* shp) {
+vector<float> compute_shape_cdf(const shape* shp) {
     if (!shp->triangles.empty()) {
         return sample_triangles_cdf(shp->triangles, shp->pos);
     } else if (!shp->lines.empty()) {
@@ -3599,11 +3599,11 @@ std::vector<float> compute_shape_cdf(const shape* shp) {
 }
 
 // Update environment CDF for sampling.
-std::vector<float> compute_environment_cdf(const environment* env) {
+vector<float> compute_environment_cdf(const environment* env) {
     auto txt = env->ke_txt;
     if (!txt) return {};
     auto size     = eval_texture_size(txt);
-    auto elem_cdf = std::vector<float>(size.x * size.y);
+    auto elem_cdf = vector<float>(size.x * size.y);
     if (!empty(txt->imgf)) {
         for (auto i = 0; i < elem_cdf.size(); i++) {
             auto ij     = vec2i{i % size.x, i / size.x};
@@ -3671,7 +3671,7 @@ void refit_bvh(const shape* shp, bvh_tree* bvh) {
 
 // Refits a scene BVH
 void refit_bvh(const scene* scn, bvh_tree* bvh) {
-    auto shape_ids = std::unordered_map<shape*, int>();
+    auto shape_ids = unordered_map<shape*, int>();
     for (auto sid = 0; sid < scn->shapes.size(); sid++)
         shape_ids[scn->shapes[sid]] = sid;
     for (auto iid = 0; iid < scn->instances.size(); iid++) {
@@ -3684,8 +3684,8 @@ void refit_bvh(const scene* scn, bvh_tree* bvh) {
 
 // Add missing names and resolve duplicated names.
 void add_missing_names(scene* scn) {
-    auto fix_names = [](auto& vals, const std::string& base) {
-        auto nmap = std::unordered_map<std::string, int>();
+    auto fix_names = [](auto& vals, const string& base) {
+        auto nmap = unordered_map<string, int>();
         for (auto val : vals) {
             if (val->name == "") val->name = base;
             if (nmap.find(val->name) == nmap.end()) {
@@ -3743,10 +3743,10 @@ void add_missing_cameras(scene* scn) {
 }
 
 // Checks for validity of the scene.
-std::vector<std::string> validate(const scene* scn, bool skip_textures) {
-    auto errs        = std::vector<std::string>();
-    auto check_names = [&errs](const auto& vals, const std::string& base) {
-        auto used = std::unordered_map<std::string, int>();
+vector<string> validate(const scene* scn, bool skip_textures) {
+    auto errs        = vector<string>();
+    auto check_names = [&errs](const auto& vals, const string& base) {
+        auto used = unordered_map<string, int>();
         for (auto val : vals) used[val->name] += 1;
         for (auto& kv : used) {
             if (kv.first == "")
@@ -3755,7 +3755,7 @@ std::vector<std::string> validate(const scene* scn, bool skip_textures) {
                 errs.push_back("duplicated " + base + " name " + kv.first);
         }
     };
-    auto check_empty_textures = [&errs](const std::vector<texture*>& vals) {
+    auto check_empty_textures = [&errs](const vector<texture*>& vals) {
         for (auto val : vals) {
             if (empty(val->imgf) && empty(val->imgb))
                 errs.push_back("empty texture " + val->name);
@@ -3775,7 +3775,7 @@ std::vector<std::string> validate(const scene* scn, bool skip_textures) {
 }
 
 // add missing camera
-camera* make_bbox_camera(const std::string& name, const bbox3f& bbox,
+camera* make_bbox_camera(const string& name, const bbox3f& bbox,
     const vec2f& film, float focal) {
     auto bbox_center = (bbox.max + bbox.min) / 2.0f;
     auto bbox_size   = bbox.max - bbox.min;
@@ -3846,7 +3846,7 @@ vec4f eval_elem_tangsp(const shape* shp, int ei) {
     if (!shp->triangles.empty()) {
         auto t    = shp->triangles[ei];
         auto norm = triangle_normal(shp->pos[t.x], shp->pos[t.y], shp->pos[t.z]);
-        auto txty = std::pair<vec3f, vec3f>();
+        auto txty = pair<vec3f, vec3f>();
         if (shp->texcoord.empty()) {
             txty = triangle_tangents_fromuv(shp->pos[t.x], shp->pos[t.y],
                 shp->pos[t.z], {0, 0}, {1, 0}, {0, 1});
@@ -3866,7 +3866,7 @@ vec4f eval_elem_tangsp(const shape* shp, int ei) {
 // Shape value interpolated using barycentric coordinates
 template <typename T>
 T eval_elem(
-    const shape* shp, const std::vector<T>& vals, int ei, const vec2f& uv) {
+    const shape* shp, const vector<T>& vals, int ei, const vec2f& uv) {
     if (vals.empty()) return {};
     if (!shp->triangles.empty()) {
         auto t = shp->triangles[ei];
@@ -4232,8 +4232,8 @@ bsdf eval_bsdf(const instance* ist, int ei, const vec2f& uv) {
 bool is_delta_bsdf(const bsdf& f) { return f.rs == 0 && f.kd == zero3f; }
 
 // Sample a shape based on a distribution.
-std::pair<int, vec2f> sample_shape(const shape* shp,
-    const std::vector<float>& elem_cdf, float re, const vec2f& ruv) {
+pair<int, vec2f> sample_shape(const shape* shp,
+    const vector<float>& elem_cdf, float re, const vec2f& ruv) {
     // TODO: implement sampling without cdf
     if (elem_cdf.empty()) return {};
     if (!shp->triangles.empty()) {
@@ -4699,7 +4699,7 @@ float sample_delta_brdf_pdf(
 
 // Sample pdf for an environment.
 float sample_environment_pdf(const environment* env,
-    const std::vector<float>& elem_cdf, const vec3f& i) {
+    const vector<float>& elem_cdf, const vec3f& i) {
     auto txt = env->ke_txt;
     if (!elem_cdf.empty() && txt) {
         auto size     = eval_texture_size(txt);
@@ -4718,7 +4718,7 @@ float sample_environment_pdf(const environment* env,
 
 // Picks a point on an environment.
 vec3f sample_environment(const environment* env,
-    const std::vector<float>& elem_cdf, float rel, const vec2f& ruv) {
+    const vector<float>& elem_cdf, float rel, const vec2f& ruv) {
     auto txt = env->ke_txt;
     if (!elem_cdf.empty() && txt) {
         auto idx  = sample_discrete(elem_cdf, rel);
@@ -4732,14 +4732,14 @@ vec3f sample_environment(const environment* env,
 }
 
 // Picks a point on a light.
-vec3f sample_light(const instance* ist, const std::vector<float>& elem_cdf,
+vec3f sample_light(const instance* ist, const vector<float>& elem_cdf,
     const vec3f& p, float rel, const vec2f& ruv) {
     auto sample = sample_shape(ist->shp, elem_cdf, rel, ruv);
     return normalize(eval_pos(ist, sample.first, sample.second) - p);
 }
 
 // Sample pdf for a light point.
-float sample_light_pdf(const instance* ist, const std::vector<float>& elem_cdf,
+float sample_light_pdf(const instance* ist, const vector<float>& elem_cdf,
     const vec3f& p, const vec3f& i, const vec3f& lp, const vec3f& ln) {
     if (ist->mat->ke == zero3f) return 0;
     // prob triangle * area triangle = area triangle mesh
@@ -4828,7 +4828,7 @@ float prob_direct(const bsdf& f) {
 // works for both surface rendering and volume rendering.
 vec3f direct_illumination(const scene* scn, const bvh_tree* bvh,
     const trace_lights* lights, const vec3f& p, int channel,
-    std::vector<instance*> mediums, rng_state& rng, float& pdf, vec3f& le) {
+    vector<instance*> mediums, rng_state& rng, float& pdf, vec3f& le) {
     auto  i      = zero3f;
     vec3f weight = vec3f{1, 1, 1};
 
@@ -5043,7 +5043,7 @@ vec3f trace_volpath(const scene* scn, const bvh_tree* bvh,
 #endif
 
     // List of mediums that contains the path. The path starts in air.
-    auto mediums = std::vector<instance*>{air};
+    auto mediums = vector<instance*>{air};
 
     // Sample color channel. This won't matter if there are no heterogeneus
     // materials.
@@ -5832,10 +5832,10 @@ image<vec4f> trace_image4f(const scene* scn, const bvh_tree* bvh,
             }
         }
     } else {
-        auto nthreads = std::thread::hardware_concurrency();
-        auto threads  = std::vector<std::thread>();
+        auto nthreads = thread::hardware_concurrency();
+        auto threads  = vector<thread>();
         for (auto tid = 0; tid < nthreads; tid++) {
-            threads.push_back(std::thread([=]() {
+            threads.push_back(thread([=]() {
                 for (auto j = tid; j < height(state->img); j += nthreads) {
                     for (auto i = 0; i < width(state->img); i++) {
                         for (auto s = 0; s < params.nsamples; s++)
@@ -5870,10 +5870,10 @@ bool trace_samples(trace_state* state, const scene* scn, const bvh_tree* bvh,
             }
         }
     } else {
-        auto nthreads = std::thread::hardware_concurrency();
-        auto threads  = std::vector<std::thread>();
+        auto nthreads = thread::hardware_concurrency();
+        auto threads  = vector<thread>();
         for (auto tid = 0; tid < nthreads; tid++) {
-            threads.push_back(std::thread([=]() {
+            threads.push_back(thread([=]() {
                 for (auto j = tid; j < height(state->img); j += nthreads) {
                     for (auto i = 0; i < width(state->img); i++) {
                         state->img[{i, j}] *= state->sample;
@@ -5916,11 +5916,11 @@ void trace_async_start(trace_state* state, const scene* scn, const bvh_tree* bvh
         }
     }
 
-    auto nthreads = std::thread::hardware_concurrency();
+    auto nthreads = thread::hardware_concurrency();
     state->threads.clear();
     state->stop = false;
     for (auto tid = 0; tid < nthreads; tid++) {
-        state->threads.push_back(std::thread([=, &params]() {
+        state->threads.push_back(thread([=, &params]() {
             for (auto s = 0; s < params.nsamples; s++) {
                 if (!tid) state->sample = s;
                 for (auto j = tid; j < height(state->img); j += nthreads) {
@@ -5950,7 +5950,7 @@ void trace_async_stop(trace_state* state) {
 
 // Trace statistics for last run used for fine tuning implementation.
 // For now returns number of paths and number of rays.
-std::pair<uint64_t, uint64_t> get_trace_stats() {
+pair<uint64_t, uint64_t> get_trace_stats() {
     return {_trace_nrays, _trace_npaths};
 }
 void reset_trace_stats() {

--- a/yocto/ygl.cpp
+++ b/yocto/ygl.cpp
@@ -4459,8 +4459,8 @@ void print_stats(const scene* scn) {
 namespace ygl {
 
 // Trace stats.
-std::atomic<uint64_t> _trace_npaths{0};
-std::atomic<uint64_t> _trace_nrays{0};
+atomic<uint64_t> _trace_npaths{0};
+atomic<uint64_t> _trace_nrays{0};
 
 // Intersect a scene handling opacity.
 scene_intersection intersect_ray_cutout(const scene* scn, const bvh_tree* bvh,

--- a/yocto/ygl.cpp
+++ b/yocto/ygl.cpp
@@ -934,7 +934,7 @@ pair<vector<vec4i>, vector<vec3f>> weld_quads(
 // Samples a set of points over a triangle mesh uniformly. The rng function
 // takes the point index and returns vec3f numbers uniform directibuted in
 // [0,1]^3. unorm and texcoord are optional.
-std::tuple<vector<vec3f>, vector<vec3f>, vector<vec2f>>
+tuple<vector<vec3f>, vector<vec3f>, vector<vec2f>>
 sample_triangles_points(const vector<vec3i>& triangles,
     const vector<vec3f>& pos, const vector<vec3f>& norm,
     const vector<vec2f>& texcoord, int npoints, int seed) {
@@ -1115,9 +1115,9 @@ bool intersect_bbox(const ray3f& ray, const bbox3f& bbox) {
     auto t0   = (bbox.min - ray.o) * invd;
     auto t1   = (bbox.max - ray.o) * invd;
     // flip based on range directions
-    if (invd.x < 0.0f) std::swap(t0.x, t1.x);
-    if (invd.y < 0.0f) std::swap(t0.y, t1.y);
-    if (invd.z < 0.0f) std::swap(t0.z, t1.z);
+    if (invd.x < 0.0f) swap(t0.x, t1.x);
+    if (invd.y < 0.0f) swap(t0.y, t1.y);
+    if (invd.z < 0.0f) swap(t0.z, t1.z);
     auto tmin = _safemax(t0.z, _safemax(t0.y, _safemax(t0.x, ray.tmin)));
     auto tmax = _safemin(t1.z, _safemin(t1.y, _safemin(t1.x, ray.tmax)));
     tmax *= 1.00000024f;  // for double: 1.0000000000000004
@@ -2190,7 +2190,7 @@ make_shape_data make_cylinder(const vec3i& steps, const vec2f& size,
         qshps[2].norm[i]  = -qshps[2].norm[i];
     }
     for (auto i = 0; i < qshps[2].quads.size(); i++)
-        std::swap(qshps[2].quads[i].x, qshps[2].quads[i].z);
+        swap(qshps[2].quads[i].x, qshps[2].quads[i].z);
 
     return merge_shape_data(qshps);
 }
@@ -2955,11 +2955,11 @@ vec3f rgb_to_hsv(const vec3f& rgb) {
     auto  r = rgb.x, g = rgb.y, b = rgb.z;
     float K = 0.f;
     if (g < b) {
-        std::swap(g, b);
+        swap(g, b);
         K = -1.f;
     }
     if (r < g) {
-        std::swap(r, g);
+        swap(r, g);
         K = -2.f / 6.f - K;
     }
 
@@ -4031,9 +4031,9 @@ vec4f eval_texture(const texture* txt, const vec2f& texcoord) {
         s = clamp(texcoord.x, 0.0f, 1.0f) * width;
         t = clamp(texcoord.y, 0.0f, 1.0f) * height;
     } else {
-        s = std::fmod(texcoord.x, 1.0f) * width;
+        s = fmod(texcoord.x, 1.0f) * width;
         if (s < 0) s += width;
-        t = std::fmod(texcoord.y, 1.0f) * height;
+        t = fmod(texcoord.y, 1.0f) * height;
         if (t < 0) t += height;
     }
 

--- a/yocto/ygl.cpp
+++ b/yocto/ygl.cpp
@@ -904,7 +904,7 @@ pair<vector<vec3i>, vector<vec3f>> weld_triangles(
     float threshold) {
     auto vid            = vector<int>();
     auto wpos           = vector<vec3f>();
-    std::tie(wpos, vid) = weld_vertices(pos, threshold);
+    tie(wpos, vid) = weld_vertices(pos, threshold);
     auto wtriangles     = vector<vec3i>();
     for (auto t : triangles) {
         t.x = vid[t.x];
@@ -919,7 +919,7 @@ pair<vector<vec4i>, vector<vec3f>> weld_quads(
     float threshold) {
     auto vid            = vector<int>();
     auto wpos           = vector<vec3f>();
-    std::tie(wpos, vid) = weld_vertices(pos, threshold);
+    tie(wpos, vid) = weld_vertices(pos, threshold);
     auto wquads         = vector<vec4i>();
     for (auto q : quads) {
         q.x = vid[q.x];
@@ -946,7 +946,7 @@ sample_triangles_points(const vector<vec3i>& triangles,
     for (auto i = 0; i < npoints; i++) {
         auto ei          = 0;
         auto uv          = zero2f;
-        std::tie(ei, uv) = sample_triangles(
+        tie(ei, uv) = sample_triangles(
             cdf, rand1f(rng), {rand1f(rng), rand1f(rng)});
         auto t         = triangles[ei];
         sampled_pos[i] = interpolate_triangle(pos[t.x], pos[t.y], pos[t.z], uv);
@@ -1390,7 +1390,7 @@ int make_bvh_node(vector<bvh_node>& nodes, vector<bvh_prim>& prims,
                                 }) -
                             prims.data());
                 if (mid == start || mid == end)
-                    throw std::runtime_error("bad build");
+                    throw runtime_error("bad build");
             } else {
                 // split along largest
                 auto largest_axis = 0;
@@ -1530,7 +1530,7 @@ void refit_bvh(bvh_tree* bvh, int nodeid) {
             node.bbox += transform_bbox(ist.frame, sbvh->nodes[0].bbox);
         }
     } else {
-        throw std::runtime_error("empty bvh");
+        throw runtime_error("empty bvh");
     }
 }
 
@@ -1572,9 +1572,9 @@ void build_embree_bvh(bvh_tree* bvh) {
     auto embree_device = get_embree_device();
     auto embree_scene  = rtcNewScene(embree_device);
     if (!bvh->points.empty()) {
-        throw std::runtime_error("embree does not support points");
+        throw runtime_error("embree does not support points");
     } else if (!bvh->lines.empty()) {
-        throw std::runtime_error("not yet implemented");
+        throw runtime_error("not yet implemented");
     } else if (!bvh->triangles.empty()) {
         auto embree_geom = rtcNewGeometry(
             embree_device, RTC_GEOMETRY_TYPE_TRIANGLE);
@@ -1589,7 +1589,7 @@ void build_embree_bvh(bvh_tree* bvh) {
         rtcCommitGeometry(embree_geom);
         rtcAttachGeometryByID(embree_scene, embree_geom, 0);
     } else if (!bvh->quads.empty()) {
-        throw std::runtime_error("not yet implemented");
+        throw runtime_error("not yet implemented");
     } else if (!bvh->instances.empty()) {
         for (auto iid = 0; iid < bvh->instances.size(); iid++) {
             auto ist         = bvh->instances[iid];
@@ -1608,7 +1608,7 @@ void build_embree_bvh(bvh_tree* bvh) {
 }
 // Refit a BVH using Embree. Calls `refit_bvh()` if Embree is not available.
 void refit_embree_bvh(bvh_tree* bvh) {
-    throw std::runtime_error("not yet implemented");
+    throw runtime_error("not yet implemented");
 }
 bool intersect_embree_bvh(const bvh_tree* bvh, const ray3f& ray, bool find_any,
     float& dist, int& iid, int& eid, vec2f& uv) {
@@ -1642,7 +1642,7 @@ void refit_embree_bvh(bvh_tree* bvh) { return refit_bvh(bvh); }
 // Intersect BVH using Embree
 bool intersect_embree_bvh(const bvh_tree* bvh, const ray3f& ray_, bool find_any,
     float& dist, int& iid, int& eid, vec2f& uv) {
-    throw std::runtime_error("this should not have been called");
+    throw runtime_error("this should not have been called");
 }
 #endif
 
@@ -1748,7 +1748,7 @@ bool intersect_bvh(const bvh_tree* bvh, const ray3f& ray_, bool find_any,
                 }
             }
         } else {
-            throw std::runtime_error("empty bvh");
+            throw runtime_error("empty bvh");
         }
 
         // check for early exit
@@ -1838,7 +1838,7 @@ bool overlap_bvh(const bvh_tree* bvh, const vec3f& pos, float max_dist,
                 }
             }
         } else {
-            throw std::runtime_error("empty bvh");
+            throw runtime_error("empty bvh");
         }
 
         // check for early exit
@@ -2235,7 +2235,7 @@ make_shape_data make_geodesic_sphere(
     shp.pos               = pos;
     shp.triangles         = triangles;
     for (auto l = 0; l < max(0, tesselation - 2); l++) {
-        std::tie(shp.triangles, shp.pos) = subdivide_triangles(
+        tie(shp.triangles, shp.pos) = subdivide_triangles(
             shp.triangles, shp.pos);
     }
     for (auto& p : shp.pos) p = normalize(p) * size / 2;
@@ -2249,7 +2249,7 @@ make_fvshape_data make_fvcube(
     const vec3i& steps, const vec3f& size, const vec3f& uvsize) {
     auto qshp  = make_cube(steps, size, uvsize, false);
     auto fvshp = make_fvshape_data{};
-    std::tie(fvshp.quads_pos, fvshp.pos) = weld_quads(qshp.quads, qshp.pos,
+    tie(fvshp.quads_pos, fvshp.pos) = weld_quads(qshp.quads, qshp.pos,
         min(0.1f * size /
             vec3f{(float)steps.x, (float)steps.y, (float)steps.z}));
     fvshp.quads_norm                     = qshp.quads;
@@ -2817,7 +2817,7 @@ make_shape_data make_hair(const vec2i& steps,
     vector<vec3f> bpos;
     vector<vec3f> bnorm;
     vector<vec2f> btexcoord;
-    std::tie(bpos, bnorm, btexcoord) = sample_triangles_points(
+    tie(bpos, bnorm, btexcoord) = sample_triangles_points(
         striangles, spos, snorm, stexcoord, steps.y, seed);
 
     auto rng  = make_rng(seed, 3);
@@ -3478,10 +3478,10 @@ void tesselate_subdiv(const subdiv* sbd, shape* shp) {
     auto texcoord       = sbd->texcoord;
     auto color          = sbd->color;
     for (auto l = 0; l < sbd->level; l++) {
-        std::tie(quads_pos, pos) = subdivide_catmullclark(quads_pos, pos);
-        std::tie(quads_texcoord, texcoord) = subdivide_catmullclark(
+        tie(quads_pos, pos) = subdivide_catmullclark(quads_pos, pos);
+        tie(quads_texcoord, texcoord) = subdivide_catmullclark(
             quads_texcoord, texcoord, true);
-        std::tie(quads_color, color) = subdivide_catmullclark(
+        tie(quads_color, color) = subdivide_catmullclark(
             quads_color, color);
     }
     auto norm = vector<vec3f>();
@@ -3516,7 +3516,7 @@ void update_transforms(
             case animation_type::bezier:
                 val = eval_keyframed_bezier(anm->times, anm->translation, time);
                 break;
-            default: throw std::runtime_error("should not have been here");
+            default: throw runtime_error("should not have been here");
         }
         for (auto target : anm->targets) target->translation = val;
     }
@@ -3594,7 +3594,7 @@ vector<float> compute_shape_cdf(const shape* shp) {
     } else if (!shp->pos.empty()) {
         return sample_points_cdf(shp->pos.size());
     } else {
-        throw std::runtime_error("empty shape not supported");
+        throw runtime_error("empty shape not supported");
     }
 }
 
@@ -3613,7 +3613,7 @@ vector<float> compute_environment_cdf(const environment* env) {
             if (i) elem_cdf[i] += elem_cdf[i - 1];
         }
     } else {
-        throw std::runtime_error("empty texture");
+        throw runtime_error("empty texture");
     }
     return elem_cdf;
 }
@@ -3717,7 +3717,7 @@ void add_missing_tangent_space(scene* scn) {
             ist->shp->tangsp = compute_tangent_space(ist->shp->triangles,
                 ist->shp->pos, ist->shp->norm, ist->shp->texcoord);
         } else {
-            throw std::runtime_error("type not supported");
+            throw runtime_error("type not supported");
         }
     }
 }
@@ -5325,7 +5325,7 @@ vec3f trace_path_nomis(const scene* scn, const bvh_tree* bvh,
             auto& elem_cdf     = lights->shape_cdf.at(lgt->shp);
             auto  eid          = 0;
             auto  euv          = zero2f;
-            std::tie(eid, euv) = sample_shape(
+            tie(eid, euv) = sample_shape(
                 lgt->shp, elem_cdf, rand1f(rng), rand2f(rng));
             auto lp   = eval_pos(lgt, eid, euv);
             auto i    = normalize(lp - p);
@@ -5459,7 +5459,7 @@ vec3f trace_direct_nomis(const scene* scn, const bvh_tree* bvh,
         auto& elem_cdf     = lights->shape_cdf.at(lgt->shp);
         auto  eid          = 0;
         auto  euv          = zero2f;
-        std::tie(eid, euv) = sample_shape(
+        tie(eid, euv) = sample_shape(
             lgt->shp, elem_cdf, rand1f(rng), rand2f(rng));
         auto lp   = eval_pos(lgt, eid, euv);
         auto i    = normalize(lp - p);
@@ -5746,7 +5746,7 @@ vec3f trace_func(const scene* scn, const bvh_tree* bvh,
         case trace_type::debug_roughness:
             return trace_debug_roughness(
                 scn, bvh, lights, ray, rng, nbounces, hit);
-        default: throw std::runtime_error("should not have gotten here");
+        default: throw runtime_error("should not have gotten here");
     }
     return zero3f;
 }
@@ -6074,7 +6074,7 @@ vec3f sample_ggx(float rs, const vec2f& rn) {
 // -----------------------------------------------------------------------------
 namespace ygl {
 
-float integrate_func_base(std::function<float(float)> f, float a, float b,
+float integrate_func_base(function<float(float)> f, float a, float b,
     int nsamples, rng_state& rng) {
     auto integral = 0.0f;
     for (auto i = 0; i < nsamples; i++) {
@@ -6086,7 +6086,7 @@ float integrate_func_base(std::function<float(float)> f, float a, float b,
     return integral;
 }
 
-float integrate_func_stratified(std::function<float(float)> f, float a, float b,
+float integrate_func_stratified(function<float(float)> f, float a, float b,
     int nsamples, rng_state& rng) {
     auto integral = 0.0f;
     for (auto i = 0; i < nsamples; i++) {
@@ -6098,8 +6098,8 @@ float integrate_func_stratified(std::function<float(float)> f, float a, float b,
     return integral;
 }
 
-float integrate_func_importance(std::function<float(float)> f,
-    std::function<float(float)> pdf, std::function<float(float)> warp,
+float integrate_func_importance(function<float(float)> f,
+    function<float(float)> pdf, function<float(float)> warp,
     int nsamples, rng_state& rng) {
     auto integral = 0.0f;
     for (auto i = 0; i < nsamples; i++) {
@@ -6121,9 +6121,9 @@ float integrate_func_importance(std::function<float(float)> f,
 // auto f = [](double x) { return sin(x); }
 // auto a = 0.0, b = (double)M_PI;
 // auto expected = (double)M_PI;
-void print_integrate_func_test(std::function<float(float)> f, float a, float b,
-    float expected, int nsamples, std::function<float(float)> pdf,
-    std::function<float(float)> warp) {
+void print_integrate_func_test(function<float(float)> f, float a, float b,
+    float expected, int nsamples, function<float(float)> pdf,
+    function<float(float)> warp) {
     auto rng = rng_state();
     printf("nsamples base base-err stratified-err importance-err\n");
     for (auto ns = 10; ns < nsamples; ns += 10) {
@@ -6139,7 +6139,7 @@ void print_integrate_func_test(std::function<float(float)> f, float a, float b,
     }
 }
 
-float integrate_func2_base(std::function<float(vec2f)> f, vec2f a, vec2f b,
+float integrate_func2_base(function<float(vec2f)> f, vec2f a, vec2f b,
     int nsamples, rng_state& rng) {
     auto integral = 0.0f;
     for (auto i = 0; i < nsamples; i++) {
@@ -6151,7 +6151,7 @@ float integrate_func2_base(std::function<float(vec2f)> f, vec2f a, vec2f b,
     return integral;
 }
 
-float integrate_func2_stratified(std::function<float(vec2f)> f, vec2f a,
+float integrate_func2_stratified(function<float(vec2f)> f, vec2f a,
     vec2f b, int nsamples, rng_state& rng) {
     auto integral  = 0.0f;
     auto nsamples2 = (int)sqrt(nsamples);
@@ -6167,8 +6167,8 @@ float integrate_func2_stratified(std::function<float(vec2f)> f, vec2f a,
     return integral;
 }
 
-float integrate_func2_importance(std::function<float(vec2f)> f,
-    std::function<float(vec2f)> pdf, std::function<vec2f(vec2f)> warp,
+float integrate_func2_importance(function<float(vec2f)> f,
+    function<float(vec2f)> pdf, function<vec2f(vec2f)> warp,
     int nsamples, rng_state& rng) {
     auto integral = 0.0f;
     for (auto i = 0; i < nsamples; i++) {
@@ -6186,9 +6186,9 @@ float integrate_func2_importance(std::function<float(vec2f)> f,
 // auto a = 0.0, b = 1.0;
 // auto expected = 3.0 / 4.0;
 // auto nsamples = 10000
-void print_integrate_func2_test(std::function<float(vec2f)> f, vec2f a, vec2f b,
-    float expected, int nsamples, std::function<float(vec2f)> pdf,
-    std::function<vec2f(vec2f)> warp) {
+void print_integrate_func2_test(function<float(vec2f)> f, vec2f a, vec2f b,
+    float expected, int nsamples, function<float(vec2f)> pdf,
+    function<vec2f(vec2f)> warp) {
     auto rng = rng_state();
     printf("nsamples base base-err stratified-err importance-err\n");
     for (auto ns = 10; ns < nsamples; ns += 10) {

--- a/yocto/ygl.h
+++ b/yocto/ygl.h
@@ -294,6 +294,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+#include <map>
 
 // -----------------------------------------------------------------------------
 // MATH CONSTANTS AND FUNCTIONS
@@ -317,6 +318,13 @@ using std::round;
 using std::sin;
 using std::sqrt;
 using std::tan;
+
+using std::string;
+using std::vector;
+using std::map;
+using std::unordered_map;
+using std::thread;
+using std::pair;
 using namespace std::string_literals;
 
 using byte = unsigned char;
@@ -1695,7 +1703,7 @@ inline mat4<T> perspective_mat(T fovy, T aspect, T near) {
 
 // Rotation conversions.
 template <typename T>
-inline std::pair<vec3<T>, T> rotation_axisangle(const vec4<T>& quat) {
+inline pair<vec3<T>, T> rotation_axisangle(const vec4<T>& quat) {
     return {normalize(vec3f{quat.x, quat.y, quat.z}), 2 * acos(quat.w)};
 }
 template <typename T>
@@ -1883,14 +1891,14 @@ inline int sample_index(int size, float r) {
 inline float sample_index_pdf(int size) { return 1.0f / size; }
 
 // Sample a discrete distribution represented by its cdf.
-inline int sample_discrete(const std::vector<float>& cdf, float r) {
+inline int sample_discrete(const vector<float>& cdf, float r) {
     r        = clamp(r * cdf.back(), 0.0f, cdf.back() - 0.00001f);
     auto idx = (int)(std::upper_bound(cdf.data(), cdf.data() + cdf.size(), r) -
                      cdf.data());
     return clamp(idx, 0, (int)cdf.size() - 1);
 }
 // Pdf for uniform discrete distribution sampling.
-inline float sample_discrete_pdf(const std::vector<float>& cdf, int idx) {
+inline float sample_discrete_pdf(const vector<float>& cdf, int idx) {
     if (idx == 0) return cdf.at(0);
     return cdf.at(idx) - cdf.at(idx - 1);
 }
@@ -1951,7 +1959,7 @@ inline float quad_area(
 }
 
 // Triangle tangent and bitangent from uv
-inline std::pair<vec3f, vec3f> triangle_tangents_fromuv(const vec3f& p0,
+inline pair<vec3f, vec3f> triangle_tangents_fromuv(const vec3f& p0,
     const vec3f& p1, const vec3f& p2, const vec2f& uv0, const vec2f& uv1,
     const vec2f& uv2) {
     // Follows the definition in http://www.terathon.com/code/tangent.html and
@@ -2020,128 +2028,128 @@ inline T interpolate_bezier_derivative(
 namespace ygl {
 
 // Compute per-vertex normals/tangents for lines/triangles/quads.
-std::vector<vec3f> compute_tangents(
-    const std::vector<vec2i>& lines, const std::vector<vec3f>& pos);
-std::vector<vec3f> compute_normals(
-    const std::vector<vec3i>& triangles, const std::vector<vec3f>& pos);
-std::vector<vec3f> compute_normals(
-    const std::vector<vec4i>& quads, const std::vector<vec3f>& pos);
+vector<vec3f> compute_tangents(
+    const vector<vec2i>& lines, const vector<vec3f>& pos);
+vector<vec3f> compute_normals(
+    const vector<vec3i>& triangles, const vector<vec3f>& pos);
+vector<vec3f> compute_normals(
+    const vector<vec4i>& quads, const vector<vec3f>& pos);
 
 // Compute per-vertex tangent space for triangle meshes.
 // Tangent space is defined by a four component vector.
 // The first three components are the tangent with respect to the u texcoord.
 // The fourth component is the sign of the tangent wrt the v texcoord.
 // Tangent frame is useful in normal mapping.
-std::vector<vec4f> compute_tangent_space(const std::vector<vec3i>& triangles,
-    const std::vector<vec3f>& pos, const std::vector<vec3f>& norm,
-    const std::vector<vec2f>& texcoord);
+vector<vec4f> compute_tangent_space(const vector<vec3i>& triangles,
+    const vector<vec3f>& pos, const vector<vec3f>& norm,
+    const vector<vec2f>& texcoord);
 
 // Apply skinning to vertex position and normals.
-std::pair<std::vector<vec3f>, std::vector<vec3f>> compute_skinning(
-    const std::vector<vec3f>& pos, const std::vector<vec3f>& norm,
-    const std::vector<vec4f>& weights, const std::vector<vec4i>& joints,
-    const std::vector<frame3f>& xforms);
+pair<vector<vec3f>, vector<vec3f>> compute_skinning(
+    const vector<vec3f>& pos, const vector<vec3f>& norm,
+    const vector<vec4f>& weights, const vector<vec4i>& joints,
+    const vector<frame3f>& xforms);
 // Apply skinning as specified in Khronos glTF.
-std::pair<std::vector<vec3f>, std::vector<vec3f>> compute_matrix_skinning(
-    const std::vector<vec3f>& pos, const std::vector<vec3f>& norm,
-    const std::vector<vec4f>& weights, const std::vector<vec4i>& joints,
-    const std::vector<mat4f>& xforms);
+pair<vector<vec3f>, vector<vec3f>> compute_matrix_skinning(
+    const vector<vec3f>& pos, const vector<vec3f>& norm,
+    const vector<vec4f>& weights, const vector<vec4i>& joints,
+    const vector<mat4f>& xforms);
 
 // Dictionary to store edge information.
-using edge_map = std::unordered_map<vec2i, vec2i>;
+using edge_map = unordered_map<vec2i, vec2i>;
 
 // Initialize an edge map with elements.
-edge_map make_edge_map(const std::vector<vec3i>& triangles);
-edge_map make_edge_map(const std::vector<vec4i>& quads);
+edge_map make_edge_map(const vector<vec3i>& triangles);
+edge_map make_edge_map(const vector<vec4i>& quads);
 // Insert an edge and return its index
 int insert_edge(edge_map& emap, const vec2i& edge);
 // Get the edge index / insertion count
 int get_edge_index(const edge_map& emap, const vec2i& edge);
 int get_edge_count(const edge_map& emap, const vec2i& edge);
 // Get list of edges / boundary edges
-std::vector<vec2i> get_edges(const edge_map& emap);
-std::vector<vec2i> get_boundary(const edge_map& emap);
+vector<vec2i> get_edges(const edge_map& emap);
+vector<vec2i> get_boundary(const edge_map& emap);
 
 // Create an array of edges.
-inline std::vector<vec2i> get_edges(const std::vector<vec3i>& triangles) {
+inline vector<vec2i> get_edges(const vector<vec3i>& triangles) {
     return get_edges(make_edge_map(triangles));
 }
-inline std::vector<vec2i> get_edges(const std::vector<vec4i>& quads) {
+inline vector<vec2i> get_edges(const vector<vec4i>& quads) {
     return get_edges(make_edge_map(quads));
 }
 
 // Convert quads to triangles
-std::vector<vec3i> convert_quads_to_triangles(const std::vector<vec4i>& quads);
+vector<vec3i> convert_quads_to_triangles(const vector<vec4i>& quads);
 // Convert quads to triangles with a diamond-like topology.
 // Quads have to be consecutive one row after another.
-std::vector<vec3i> convert_quads_to_triangles(
-    const std::vector<vec4i>& quads, int row_length);
+vector<vec3i> convert_quads_to_triangles(
+    const vector<vec4i>& quads, int row_length);
 
 // Convert beziers to lines using 3 lines for each bezier.
-std::vector<vec2i> convert_bezier_to_lines(const std::vector<vec4i>& beziers);
+vector<vec2i> convert_bezier_to_lines(const vector<vec4i>& beziers);
 
 // Convert face-varying data to single primitives. Returns the quads indices
 // and face ids and filled vectors for pos, norm and texcoord.
-void convert_face_varying(std::vector<vec4i>& qquads, std::vector<vec3f>& qpos,
-    std::vector<vec3f>& qnorm, std::vector<vec2f>& qtexcoord,
-    std::vector<vec4f>& qcolor, const std::vector<vec4i>& quads_pos,
-    const std::vector<vec4i>& quads_norm,
-    const std::vector<vec4i>& quads_texcoord,
-    const std::vector<vec4i>& quads_color, const std::vector<vec3f>& pos,
-    const std::vector<vec3f>& norm, const std::vector<vec2f>& texcoord,
-    const std::vector<vec4f>& color);
+void convert_face_varying(vector<vec4i>& qquads, vector<vec3f>& qpos,
+    vector<vec3f>& qnorm, vector<vec2f>& qtexcoord,
+    vector<vec4f>& qcolor, const vector<vec4i>& quads_pos,
+    const vector<vec4i>& quads_norm,
+    const vector<vec4i>& quads_texcoord,
+    const vector<vec4i>& quads_color, const vector<vec3f>& pos,
+    const vector<vec3f>& norm, const vector<vec2f>& texcoord,
+    const vector<vec4f>& color);
 
 // Subdivide lines by splitting each line in half.
 template <typename T>
-std::pair<std::vector<vec2i>, std::vector<T>> subdivide_lines(
-    const std::vector<vec2i>& lines, const std::vector<T>& vert);
+pair<vector<vec2i>, vector<T>> subdivide_lines(
+    const vector<vec2i>& lines, const vector<T>& vert);
 // Subdivide triangle by splitting each triangle in four, creating new
 // vertices for each edge.
 template <typename T>
-std::pair<std::vector<vec3i>, std::vector<T>> subdivide_triangles(
-    const std::vector<vec3i>& triangles, const std::vector<T>& vert);
+pair<vector<vec3i>, vector<T>> subdivide_triangles(
+    const vector<vec3i>& triangles, const vector<T>& vert);
 // Subdivide quads by splitting each quads in four, creating new
 // vertices for each edge and for each face.
 template <typename T>
-std::pair<std::vector<vec4i>, std::vector<T>> subdivide_quads(
-    const std::vector<vec4i>& quads, const std::vector<T>& vert);
+pair<vector<vec4i>, vector<T>> subdivide_quads(
+    const vector<vec4i>& quads, const vector<T>& vert);
 // Subdivide beziers by splitting each segment in two.
 template <typename T>
-std::pair<std::vector<vec4i>, std::vector<T>> subdivide_beziers(
-    const std::vector<vec4i>& beziers, const std::vector<T>& vert);
+pair<vector<vec4i>, vector<T>> subdivide_beziers(
+    const vector<vec4i>& beziers, const vector<T>& vert);
 // Subdivide quads using Carmull-Clark subdivision rules.
 template <typename T>
-std::pair<std::vector<vec4i>, std::vector<T>> subdivide_catmullclark(
-    const std::vector<vec4i>& quads, const std::vector<T>& vert,
+pair<vector<vec4i>, vector<T>> subdivide_catmullclark(
+    const vector<vec4i>& quads, const vector<T>& vert,
     bool lock_boundary = false);
 
 // Weld vertices within a threshold. For noe the implementation is O(n^2).
-std::pair<std::vector<vec3f>, std::vector<int>> weld_vertices(
-    const std::vector<vec3f>& pos, float threshold);
-std::pair<std::vector<vec3i>, std::vector<vec3f>> weld_triangles(
-    const std::vector<vec3i>& triangles, const std::vector<vec3f>& pos,
+pair<vector<vec3f>, vector<int>> weld_vertices(
+    const vector<vec3f>& pos, float threshold);
+pair<vector<vec3i>, vector<vec3f>> weld_triangles(
+    const vector<vec3i>& triangles, const vector<vec3f>& pos,
     float threshold);
-std::pair<std::vector<vec4i>, std::vector<vec3f>> weld_quads(
-    const std::vector<vec4i>& quads, const std::vector<vec3f>& pos,
+pair<vector<vec4i>, vector<vec3f>> weld_quads(
+    const vector<vec4i>& quads, const vector<vec3f>& pos,
     float threshold);
 
 // Pick a point in a point set uniformly.
 inline int sample_points(int npoints, float re) {
     return sample_index(npoints, re);
 }
-inline std::vector<float> sample_points_cdf(int npoints) {
-    auto cdf = std::vector<float>(npoints);
+inline vector<float> sample_points_cdf(int npoints) {
+    auto cdf = vector<float>(npoints);
     for (auto i = 0; i < cdf.size(); i++) cdf[i] = 1 + (i ? cdf[i - 1] : 0);
     return cdf;
 }
-inline int sample_points(const std::vector<float>& cdf, float re) {
+inline int sample_points(const vector<float>& cdf, float re) {
     return sample_discrete(cdf, re);
 }
 
 // Pick a point on lines uniformly.
-inline std::vector<float> sample_lines_cdf(
-    const std::vector<vec2i>& lines, const std::vector<vec3f>& pos) {
-    auto cdf = std::vector<float>(lines.size());
+inline vector<float> sample_lines_cdf(
+    const vector<vec2i>& lines, const vector<vec3f>& pos) {
+    auto cdf = vector<float>(lines.size());
     for (auto i = 0; i < cdf.size(); i++) {
         auto l = lines[i];
         auto w = line_length(pos[l.x], pos[l.y]);
@@ -2149,15 +2157,15 @@ inline std::vector<float> sample_lines_cdf(
     }
     return cdf;
 }
-inline std::pair<int, float> sample_lines(
-    const std::vector<float>& cdf, float re, float ru) {
+inline pair<int, float> sample_lines(
+    const vector<float>& cdf, float re, float ru) {
     return {sample_discrete(cdf, re), ru};
 }
 
 // Pick a point on a triangle mesh uniformly.
-inline std::vector<float> sample_triangles_cdf(
-    const std::vector<vec3i>& triangles, const std::vector<vec3f>& pos) {
-    auto cdf = std::vector<float>(triangles.size());
+inline vector<float> sample_triangles_cdf(
+    const vector<vec3i>& triangles, const vector<vec3f>& pos) {
+    auto cdf = vector<float>(triangles.size());
     for (auto i = 0; i < cdf.size(); i++) {
         auto t = triangles[i];
         auto w = triangle_area(pos[t.x], pos[t.y], pos[t.z]);
@@ -2165,15 +2173,15 @@ inline std::vector<float> sample_triangles_cdf(
     }
     return cdf;
 }
-inline std::pair<int, vec2f> sample_triangles(
-    const std::vector<float>& cdf, float re, const vec2f& ruv) {
+inline pair<int, vec2f> sample_triangles(
+    const vector<float>& cdf, float re, const vec2f& ruv) {
     return {sample_discrete(cdf, re), sample_triangle(ruv)};
 }
 
 // Pick a point on a quad mesh uniformly.
-inline std::vector<float> sample_quads_cdf(
-    const std::vector<vec4i>& quads, const std::vector<vec3f>& pos) {
-    auto cdf = std::vector<float>(quads.size());
+inline vector<float> sample_quads_cdf(
+    const vector<vec4i>& quads, const vector<vec3f>& pos) {
+    auto cdf = vector<float>(quads.size());
     for (auto i = 0; i < cdf.size(); i++) {
         auto q = quads[i];
         auto w = quad_area(pos[q.x], pos[q.y], pos[q.z], pos[q.w]);
@@ -2181,17 +2189,17 @@ inline std::vector<float> sample_quads_cdf(
     }
     return cdf;
 }
-inline std::pair<int, vec2f> sample_quads(
-    const std::vector<float>& cdf, float re, const vec2f& ruv) {
+inline pair<int, vec2f> sample_quads(
+    const vector<float>& cdf, float re, const vec2f& ruv) {
     return {sample_discrete(cdf, re), ruv};
 }
 
 // Samples a set of points over a triangle mesh uniformly. Returns pos, norm
 // and texcoord of the sampled points.
-std::tuple<std::vector<vec3f>, std::vector<vec3f>, std::vector<vec2f>>
-sample_triangles_points(const std::vector<vec3i>& triangles,
-    const std::vector<vec3f>& pos, const std::vector<vec3f>& norm,
-    const std::vector<vec2f>& texcoord, int npoints, int seed = 7);
+std::tuple<vector<vec3f>, vector<vec3f>, vector<vec2f>>
+sample_triangles_points(const vector<vec3i>& triangles,
+    const vector<vec3f>& pos, const vector<vec3f>& norm,
+    const vector<vec2f>& texcoord, int npoints, int seed = 7);
 
 }  // namespace ygl
 
@@ -2305,23 +2313,23 @@ struct bvh_instance {
 // call `build_bvh()`.
 struct bvh_tree {
     // data for shape BVH
-    std::vector<vec3f> pos;        // Positions for shape BVHs.
-    std::vector<float> radius;     // Radius for shape BVHs.
-    std::vector<int>   points;     // Points for shape BVHs.
-    std::vector<vec2i> lines;      // Lines for shape BVHs.
-    std::vector<vec3i> triangles;  // Triangles for shape BVHs.
-    std::vector<vec4i> quads;      // Quads for shape BVHs.
+    vector<vec3f> pos;        // Positions for shape BVHs.
+    vector<float> radius;     // Radius for shape BVHs.
+    vector<int>   points;     // Points for shape BVHs.
+    vector<vec2i> lines;      // Lines for shape BVHs.
+    vector<vec3i> triangles;  // Triangles for shape BVHs.
+    vector<vec4i> quads;      // Quads for shape BVHs.
 
     // data for instance BVH
-    std::vector<bvh_instance> instances;   // instances
-    std::vector<bvh_tree*>    shape_bvhs;  // shape bvhs
+    vector<bvh_instance> instances;   // instances
+    vector<bvh_tree*>    shape_bvhs;  // shape bvhs
 
     // optional application specific data to key from a pointer to internal ids
-    std::unordered_map<void*, int> instance_ids;
-    std::unordered_map<void*, int> shape_ids;
+    unordered_map<void*, int> instance_ids;
+    unordered_map<void*, int> shape_ids;
 
     // bvh nodes
-    std::vector<bvh_node> nodes;  // Internal nodes.
+    vector<bvh_node> nodes;  // Internal nodes.
 
     // Embree opaque data
     void* embree_bvh = nullptr;
@@ -2363,27 +2371,27 @@ namespace ygl {
 
 // Shape data returned by make_<shape> functions.
 struct make_shape_data {
-    std::vector<vec3f> pos;       // positions
-    std::vector<vec3f> norm;      // normals/tangents
-    std::vector<vec2f> texcoord;  // texture coordinates
-    std::vector<float> radius;    // radius for lines and points
+    vector<vec3f> pos;       // positions
+    vector<vec3f> norm;      // normals/tangents
+    vector<vec2f> texcoord;  // texture coordinates
+    vector<float> radius;    // radius for lines and points
 
-    std::vector<int>   points;     // points
-    std::vector<vec2i> lines;      // lines
-    std::vector<vec3i> triangles;  // triangles
-    std::vector<vec4i> quads;      // quads
-    std::vector<vec4i> beziers;    // beziers
+    vector<int>   points;     // points
+    vector<vec2i> lines;      // lines
+    vector<vec3i> triangles;  // triangles
+    vector<vec4i> quads;      // quads
+    vector<vec4i> beziers;    // beziers
 };
 
 // Shape data returned by make_fv<shape> functions.
 struct make_fvshape_data {
-    std::vector<vec3f> pos;       // positions
-    std::vector<vec3f> norm;      // normals/tangents
-    std::vector<vec2f> texcoord;  // texture coordinates
+    vector<vec3f> pos;       // positions
+    vector<vec3f> norm;      // normals/tangents
+    vector<vec2f> texcoord;  // texture coordinates
 
-    std::vector<vec4i> quads_pos;       // facevarying quads for pos
-    std::vector<vec4i> quads_norm;      // facevarying quads for norm
-    std::vector<vec4i> quads_texcoord;  // facevarying quads for texcoord
+    vector<vec4i> quads_pos;       // facevarying quads for pos
+    vector<vec4i> quads_norm;      // facevarying quads for norm
+    vector<vec4i> quads_texcoord;  // facevarying quads for texcoord
 };
 
 // Make examples shapes that are not watertight (besides quads).
@@ -2440,7 +2448,7 @@ make_shape_data make_random_points(int num, const vec3f& size, float uvsize,
 
 // Make a bezier circle. Returns bezier, pos.
 make_shape_data make_bezier_circle(
-    std::vector<vec4i>& beziers, std::vector<vec3f>& pos);
+    vector<vec4i>& beziers, vector<vec3f>& pos);
 
 // Make a hair ball around a shape.  Returns lines, pos, norm, texcoord, radius.
 // length: minimum and maximum length
@@ -2449,14 +2457,14 @@ make_shape_data make_bezier_circle(
 // clump: clump added to hair (number/strength)
 // rotation: rotation added to hair (angle/strength)
 make_shape_data make_hair(const vec2i& steps,
-    const std::vector<vec3i>& striangles, const std::vector<vec3f>& spos,
-    const std::vector<vec3f>& snorm, const std::vector<vec2f>& stexcoord,
+    const vector<vec3i>& striangles, const vector<vec3f>& spos,
+    const vector<vec3f>& snorm, const vector<vec2f>& stexcoord,
     const vec2f& length = {0.1f, 0.1f}, const vec2f& rad = {0.001f, 0.001f},
     const vec2f& noise = zero2f, const vec2f& clump = zero2f,
     const vec2f& rotation = zero2f, int seed = 7);
 
 // Helper to concatenated shape data for non-facevarying shapes.
-make_shape_data merge_shape_data(const std::vector<make_shape_data>& shapes);
+make_shape_data merge_shape_data(const vector<make_shape_data>& shapes);
 
 }  // namespace ygl
 
@@ -2485,7 +2493,7 @@ struct image {
 
     // private data
     vec2i          extents = {0, 0};
-    std::vector<T> data    = {};
+    vector<T> data    = {};
 };
 
 // Size
@@ -2520,11 +2528,11 @@ const T* data(const image<T>& img) {
     return img.data.data();
 }
 template <typename T>
-std::vector<T>& data_vector(image<T>& img) {
+vector<T>& data_vector(image<T>& img) {
     return img.data;
 }
 template <typename T>
-const std::vector<T>& data_vector(const image<T>& img) {
+const vector<T>& data_vector(const image<T>& img) {
     return img.data;
 }
 
@@ -2734,7 +2742,7 @@ namespace ygl {
 
 // Find the first keyframe value that is greater than the argument.
 inline int eval_keyframed_index(
-    const std::vector<float>& times, const float& time) {
+    const vector<float>& times, const float& time) {
     for (auto i = 0; i < times.size(); i++)
         if (times[i] > time) return i;
     return (int)times.size();
@@ -2743,7 +2751,7 @@ inline int eval_keyframed_index(
 // Evaluates a keyframed value using step interpolation.
 template <typename T>
 inline T eval_keyframed_step(
-    const std::vector<float>& times, const std::vector<T>& vals, float time) {
+    const vector<float>& times, const vector<T>& vals, float time) {
     if (time <= times.front()) return vals.front();
     if (time >= times.back()) return vals.back();
     time     = clamp(time, times.front(), times.back() - 0.001f);
@@ -2753,8 +2761,8 @@ inline T eval_keyframed_step(
 
 // Evaluates a keyframed value using linear interpolation.
 template <typename T>
-inline vec4f eval_keyframed_slerp(const std::vector<float>& times,
-    const std::vector<vec4f>& vals, float time) {
+inline vec4f eval_keyframed_slerp(const vector<float>& times,
+    const vector<vec4f>& vals, float time) {
     if (time <= times.front()) return vals.front();
     if (time >= times.back()) return vals.back();
     time     = clamp(time, times.front(), times.back() - 0.001f);
@@ -2766,7 +2774,7 @@ inline vec4f eval_keyframed_slerp(const std::vector<float>& times,
 // Evaluates a keyframed value using linear interpolation.
 template <typename T>
 inline T eval_keyframed_linear(
-    const std::vector<float>& times, const std::vector<T>& vals, float time) {
+    const vector<float>& times, const vector<T>& vals, float time) {
     if (time <= times.front()) return vals.front();
     if (time >= times.back()) return vals.back();
     time     = clamp(time, times.front(), times.back() - 0.001f);
@@ -2778,7 +2786,7 @@ inline T eval_keyframed_linear(
 // Evaluates a keyframed value using Bezier interpolation.
 template <typename T>
 inline T eval_keyframed_bezier(
-    const std::vector<float>& times, const std::vector<T>& vals, float time) {
+    const vector<float>& times, const vector<T>& vals, float time) {
     if (time <= times.front()) return vals.front();
     if (time >= times.back()) return vals.back();
     time     = clamp(time, times.front(), times.back() - 0.001f);
@@ -2818,7 +2826,7 @@ struct volume {
 
     // private data
     vec3i          extents = {0, 0};
-    std::vector<T> data    = {};
+    vector<T> data    = {};
 };
 
 // Size
@@ -2877,11 +2885,11 @@ const T* data(const volume<T>& vol) {
     return vol.data.data();
 }
 template <typename T>
-std::vector<T>& data_vector(volume<T>& vol) {
+vector<T>& data_vector(volume<T>& vol) {
     return vol.data;
 }
 template <typename T>
-const std::vector<T>& data_vector(const volume<T>& vol) {
+const vector<T>& data_vector(const volume<T>& vol) {
     return vol.data;
 }
 
@@ -2926,7 +2934,7 @@ struct bvh_tree;
 
 // Camera.
 struct camera {
-    std::string name     = "";                // name
+    string name     = "";                // name
     frame3f     frame    = identity_frame3f;  // transform frame
     bool        ortho    = false;             // orthographic
     vec2f       film     = {0.036f, 0.024f};  // film size (default: 35mm)
@@ -2937,8 +2945,8 @@ struct camera {
 
 // Texture containing either an LDR or HDR image.
 struct texture {
-    std::string  name        = "";     // name
-    std::string  path        = "";     // file path
+    string  name        = "";     // name
+    string  path        = "";     // file path
     image<vec4f> imgf        = {};     // hdr image in linear color space
     image<vec4b> imgb        = {};     // ldr image in srgb color space
     bool         clamp       = false;  // clamp textures coordinates
@@ -2950,8 +2958,8 @@ struct texture {
 
 // Volumetric texture containing either an HDR image.
 struct voltexture {
-    std::string   name   = "";     // name
-    std::string   path   = "";     // file path
+    string   name   = "";     // name
+    string   path   = "";     // file path
     volume<float> vol    = {};     // volume
     bool          clamp  = false;  // clamp textures coordinates
     bool          linear = true;   // use trilinear interpolation
@@ -2961,7 +2969,7 @@ struct voltexture {
 // For surfaces, uses a microfacet model with thin sheet transmission.
 // The model is based on glTF for compatibility and adapted to OBJ.
 struct material {
-    std::string name          = "";     // name
+    string name          = "";     // name
     bool        base_metallic = false;  // base-metallic parametrization
     bool        gltf_textures = false;  // glTF packed textures
     bool        double_sided  = false;  // double sided rendering
@@ -3001,49 +3009,49 @@ struct material {
 // Shape data represented as an indexed meshes of elements.
 // May contain either tringles, lines or a set of vertices.
 struct shape {
-    std::string name = "";  // name
-    std::string path = "";  // path for glTF buffers
+    string name = "";  // name
+    string path = "";  // path for glTF buffers
 
     // primitives
-    std::vector<int>   points    = {};  // points
-    std::vector<vec2i> lines     = {};  // lines
-    std::vector<vec3i> triangles = {};  // triangles
+    vector<int>   points    = {};  // points
+    vector<vec2i> lines     = {};  // lines
+    vector<vec3i> triangles = {};  // triangles
 
     // vertex data
-    std::vector<vec3f> pos      = {};  // positions
-    std::vector<vec3f> norm     = {};  // normals/tangents
-    std::vector<vec2f> texcoord = {};  // texcoord coordinates
-    std::vector<vec4f> color    = {};  // colors
-    std::vector<float> radius   = {};  // radia for lines/points
-    std::vector<vec4f> tangsp   = {};  // tangent space for triangles
+    vector<vec3f> pos      = {};  // positions
+    vector<vec3f> norm     = {};  // normals/tangents
+    vector<vec2f> texcoord = {};  // texcoord coordinates
+    vector<vec4f> color    = {};  // colors
+    vector<float> radius   = {};  // radia for lines/points
+    vector<vec4f> tangsp   = {};  // tangent space for triangles
 };
 
 // Subdivision surface.
 struct subdiv {
-    std::string name            = "";    // name
-    std::string path            = "";    // path for glTF buffers
+    string name            = "";    // name
+    string path            = "";    // path for glTF buffers
     int         level           = 0;     // subdivision level
     bool        catmull_clark   = true;  // catmull clark subdiv
     bool        compute_normals = true;  // faceted subdivision
 
     // primitives
-    std::vector<vec4i> quads_pos      = {};  // quads for position
-    std::vector<vec4i> quads_texcoord = {};  // quads for texture coordinates
-    std::vector<vec4i> quads_color    = {};  // quads for color
+    vector<vec4i> quads_pos      = {};  // quads for position
+    vector<vec4i> quads_texcoord = {};  // quads for texture coordinates
+    vector<vec4i> quads_color    = {};  // quads for color
 
     // creases
-    std::vector<vec3i> crease_pos      = {};  // crease for position
-    std::vector<vec3i> crease_texcoord = {};  // crease for texture coordinates
+    vector<vec3i> crease_pos      = {};  // crease for position
+    vector<vec3i> crease_texcoord = {};  // crease for texture coordinates
 
     // vertex data
-    std::vector<vec3f> pos      = {};  // positions
-    std::vector<vec2f> texcoord = {};  // texcoord coordinates
-    std::vector<vec4f> color    = {};  // colors
+    vector<vec3f> pos      = {};  // positions
+    vector<vec2f> texcoord = {};  // texcoord coordinates
+    vector<vec4f> color    = {};  // colors
 };
 
 // Shape instance.
 struct instance {
-    std::string name  = "";                // name
+    string name  = "";                // name
     frame3f     frame = identity_frame3f;  // transform frame
     shape*      shp   = nullptr;           // shape
     material*   mat   = nullptr;           // material
@@ -3052,7 +3060,7 @@ struct instance {
 
 // Environment map.
 struct environment {
-    std::string name   = "";                // name
+    string name   = "";                // name
     frame3f     frame  = identity_frame3f;  // transform frame
     vec3f       ke     = {0, 0, 0};         // emission color
     texture*    ke_txt = nullptr;           // emission texture
@@ -3060,19 +3068,19 @@ struct environment {
 
 // Node in a transform hierarchy.
 struct node {
-    std::string        name        = "";                // name
+    string        name        = "";                // name
     node*              parent      = nullptr;           // parent
     frame3f            local       = identity_frame3f;  // transform frame
     vec3f              translation = {0, 0, 0};         // translation
     vec4f              rotation    = {0, 0, 0, 1};      // rotation
     vec3f              scale       = {1, 1, 1};         // scale
-    std::vector<float> weights     = {};                // morph weights
+    vector<float> weights     = {};                // morph weights
     camera*            cam         = nullptr;           // camera
     instance*          ist         = nullptr;           // instance
     environment*       env         = nullptr;           // environment
 
     // compute properties
-    std::vector<node*> children = {};  // child nodes
+    vector<node*> children = {};  // child nodes
 };
 
 // Keyframe type.
@@ -3080,16 +3088,16 @@ enum struct animation_type { linear, step, bezier };
 
 // Keyframe data.
 struct animation {
-    std::string                     name  = "";  // name
-    std::string                     path  = "";  // path for glTF buffer
-    std::string                     group = "";  // group
+    string                     name  = "";  // name
+    string                     path  = "";  // path for glTF buffer
+    string                     group = "";  // group
     animation_type                  type  = animation_type::linear;  // type
-    std::vector<float>              times = {};        // keyframe times
-    std::vector<vec3f>              translation = {};  // translation keyframes
-    std::vector<vec4f>              rotation    = {};  // rotation keyframes
-    std::vector<vec3f>              scale       = {};  // scale keyframes
-    std::vector<std::vector<float>> weights     = {};  // morph weight keyframes
-    std::vector<node*>              targets     = {};  // target nodes
+    vector<float>              times = {};        // keyframe times
+    vector<vec3f>              translation = {};  // translation keyframes
+    vector<vec4f>              rotation    = {};  // rotation keyframes
+    vector<vec3f>              scale       = {};  // scale keyframes
+    vector<vector<float>> weights     = {};  // morph weight keyframes
+    vector<node*>              targets     = {};  // target nodes
 };
 
 // Scene comprised an array of objects whose memory is owened by the scene.
@@ -3100,17 +3108,17 @@ struct animation {
 // the hierarchy. Animation is also optional, with keyframe data that
 // updates node transformations only if defined.
 struct scene {
-    std::string               name         = "";  // name
-    std::vector<camera*>      cameras      = {};  // cameras
-    std::vector<shape*>       shapes       = {};  // shapes
-    std::vector<subdiv*>      subdivs      = {};  // subdivs
-    std::vector<instance*>    instances    = {};  // instances
-    std::vector<material*>    materials    = {};  // materials
-    std::vector<texture*>     textures     = {};  // textures
-    std::vector<environment*> environments = {};  // environments
-    std::vector<voltexture*>  voltextures  = {};  // volume textures
-    std::vector<node*>        nodes        = {};  // node hierarchy [optional]
-    std::vector<animation*>   animations   = {};  // animations [optional]
+    string               name         = "";  // name
+    vector<camera*>      cameras      = {};  // cameras
+    vector<shape*>       shapes       = {};  // shapes
+    vector<subdiv*>      subdivs      = {};  // subdivs
+    vector<instance*>    instances    = {};  // instances
+    vector<material*>    materials    = {};  // materials
+    vector<texture*>     textures     = {};  // textures
+    vector<environment*> environments = {};  // environments
+    vector<voltexture*>  voltextures  = {};  // volume textures
+    vector<node*>        nodes        = {};  // node hierarchy [optional]
+    vector<animation*>   animations   = {};  // animations [optional]
 
     // cleanup
     ~scene();
@@ -3139,20 +3147,20 @@ namespace ygl {
 
 // Update node transforms.
 void update_transforms(
-    scene* scn, float time = 0, const std::string& anim_group = "");
+    scene* scn, float time = 0, const string& anim_group = "");
 // Compute animation range.
 vec2f compute_animation_range(
-    const scene* scn, const std::string& anim_group = "");
+    const scene* scn, const string& anim_group = "");
 
 // Computes shape/scene approximate bounds.
 bbox3f compute_bbox(const shape* shp);
 bbox3f compute_bbox(const scene* scn);
 
 // Generate a distribution for sampling a shape uniformly based on area/length.
-std::vector<float> compute_shape_cdf(const shape* shp);
+vector<float> compute_shape_cdf(const shape* shp);
 // Generate a distribution for sampling an environment texture uniformly
 // based on angle and texture intensity.
-std::vector<float> compute_environment_cdf(const environment* env);
+vector<float> compute_environment_cdf(const environment* env);
 
 // Updates/refits bvh.
 bvh_tree* build_bvh(const shape* shp, bool high_quality, bool embree = false);
@@ -3171,13 +3179,13 @@ void add_missing_tangent_space(scene* scn);
 void add_missing_materials(scene* scn);
 void add_missing_cameras(scene* scn);
 // Checks for validity of the scene.
-std::vector<std::string> validate(const scene* scn, bool skip_textures = false);
+vector<string> validate(const scene* scn, bool skip_textures = false);
 
 // make camera
-camera* make_bbox_camera(const std::string& name, const bbox3f& bbox,
+camera* make_bbox_camera(const string& name, const bbox3f& bbox,
     const vec2f& film = {0.036f, 0.024f}, float focal = 0.050f);
 // make default material
-inline material* make_default_material(const std::string& name) {
+inline material* make_default_material(const string& name) {
     auto mat  = new material();
     mat->name = name;
     mat->kd   = {0.2f, 0.2f, 0.2f};
@@ -3186,7 +3194,7 @@ inline material* make_default_material(const std::string& name) {
 
 // Add a sky environment
 inline environment* make_sky_environment(
-    const std::string& name, float sun_angle = pif / 4) {
+    const string& name, float sun_angle = pif / 4) {
     auto txt    = new texture();
     txt->name   = name;
     txt->path   = "textures/" + name + ".hdr";
@@ -3337,7 +3345,7 @@ enum struct trace_type {
     debug_roughness,    // debug - roughness
 };
 
-const auto trace_type_names = std::vector<std::string>{"path", "volpath",
+const auto trace_type_names = vector<string>{"path", "volpath",
     "direct", "environment", "eyelight", "path_nomis", "path_naive",
     "direct_nomis", "debug_normal", "debug_albedo", "debug_texcoord",
     "debug_frontfacing", "debug_diffuse", "debug_specular", "debug_roughness"};
@@ -3361,10 +3369,10 @@ struct trace_params {
 
 // Trace lights used during rendering.
 struct trace_lights {
-    std::vector<instance*>    lights;        // instance lights
-    std::vector<environment*> environments;  // environments lights
-    std::unordered_map<shape*, std::vector<float>> shape_cdf;      // shape cdfs
-    std::unordered_map<environment*, std::vector<float>> env_cdf;  // env cdfs
+    vector<instance*>    lights;        // instance lights
+    vector<environment*> environments;  // environments lights
+    unordered_map<shape*, vector<float>> shape_cdf;      // shape cdfs
+    unordered_map<environment*, vector<float>> env_cdf;  // env cdfs
 };
 
 // Trace data used during rendering. Initialize with `make_trace_state()`
@@ -3377,7 +3385,7 @@ struct trace_state {
     image<int>               samples = {};  // samples per pixel
     image<rng_state>         rng     = {};  // random number generators
     int                      sample  = 0;   // current sample being rendered
-    std::vector<std::thread> threads;       // threads used during rendering
+    vector<thread> threads;       // threads used during rendering
     bool                     stop = false;  // stop flag for threads
 };
 
@@ -3406,7 +3414,7 @@ void trace_async_stop(trace_state* state);
 
 // Trace statistics for last run used for fine tuning implementation.
 // For now returns number of paths and number of rays.
-std::pair<uint64_t, uint64_t> get_trace_stats();
+pair<uint64_t, uint64_t> get_trace_stats();
 void                          reset_trace_stats();
 
 }  // namespace ygl

--- a/yocto/ygl.h
+++ b/yocto/ygl.h
@@ -325,6 +325,10 @@ using std::map;
 using std::unordered_map;
 using std::thread;
 using std::pair;
+using std::tie;
+using std::tuple;
+using std::function;
+using std::runtime_error;
 using namespace std::string_literals;
 
 using byte = unsigned char;

--- a/yocto/ygl.h
+++ b/yocto/ygl.h
@@ -318,6 +318,8 @@ using std::round;
 using std::sin;
 using std::sqrt;
 using std::tan;
+using std::fmod;
+using std::swap;
 
 using std::string;
 using std::vector;
@@ -2201,7 +2203,7 @@ inline pair<int, vec2f> sample_quads(
 
 // Samples a set of points over a triangle mesh uniformly. Returns pos, norm
 // and texcoord of the sampled points.
-std::tuple<vector<vec3f>, vector<vec3f>, vector<vec2f>>
+tuple<vector<vec3f>, vector<vec3f>, vector<vec2f>>
 sample_triangles_points(const vector<vec3i>& triangles,
     const vector<vec3f>& pos, const vector<vec3f>& norm,
     const vector<vec2f>& texcoord, int npoints, int seed = 7);

--- a/yocto/ygl.h
+++ b/yocto/ygl.h
@@ -320,13 +320,13 @@ using std::sqrt;
 using std::tan;
 using std::fmod;
 using std::swap;
+using std::get;
 
 using std::string;
 using std::vector;
 using std::map;
 using std::unordered_map;
 using std::thread;
-using std::pair;
 using std::tie;
 using std::tuple;
 using std::function;
@@ -1710,7 +1710,7 @@ inline mat4<T> perspective_mat(T fovy, T aspect, T near) {
 
 // Rotation conversions.
 template <typename T>
-inline pair<vec3<T>, T> rotation_axisangle(const vec4<T>& quat) {
+inline tuple<vec3<T>, T> rotation_axisangle(const vec4<T>& quat) {
     return {normalize(vec3f{quat.x, quat.y, quat.z}), 2 * acos(quat.w)};
 }
 template <typename T>
@@ -1966,7 +1966,7 @@ inline float quad_area(
 }
 
 // Triangle tangent and bitangent from uv
-inline pair<vec3f, vec3f> triangle_tangents_fromuv(const vec3f& p0,
+inline tuple<vec3f, vec3f> triangle_tangents_fromuv(const vec3f& p0,
     const vec3f& p1, const vec3f& p2, const vec2f& uv0, const vec2f& uv1,
     const vec2f& uv2) {
     // Follows the definition in http://www.terathon.com/code/tangent.html and
@@ -2052,12 +2052,12 @@ vector<vec4f> compute_tangent_space(const vector<vec3i>& triangles,
     const vector<vec2f>& texcoord);
 
 // Apply skinning to vertex position and normals.
-pair<vector<vec3f>, vector<vec3f>> compute_skinning(
+tuple<vector<vec3f>, vector<vec3f>> compute_skinning(
     const vector<vec3f>& pos, const vector<vec3f>& norm,
     const vector<vec4f>& weights, const vector<vec4i>& joints,
     const vector<frame3f>& xforms);
 // Apply skinning as specified in Khronos glTF.
-pair<vector<vec3f>, vector<vec3f>> compute_matrix_skinning(
+tuple<vector<vec3f>, vector<vec3f>> compute_matrix_skinning(
     const vector<vec3f>& pos, const vector<vec3f>& norm,
     const vector<vec4f>& weights, const vector<vec4i>& joints,
     const vector<mat4f>& xforms);
@@ -2108,35 +2108,35 @@ void convert_face_varying(vector<vec4i>& qquads, vector<vec3f>& qpos,
 
 // Subdivide lines by splitting each line in half.
 template <typename T>
-pair<vector<vec2i>, vector<T>> subdivide_lines(
+tuple<vector<vec2i>, vector<T>> subdivide_lines(
     const vector<vec2i>& lines, const vector<T>& vert);
 // Subdivide triangle by splitting each triangle in four, creating new
 // vertices for each edge.
 template <typename T>
-pair<vector<vec3i>, vector<T>> subdivide_triangles(
+tuple<vector<vec3i>, vector<T>> subdivide_triangles(
     const vector<vec3i>& triangles, const vector<T>& vert);
 // Subdivide quads by splitting each quads in four, creating new
 // vertices for each edge and for each face.
 template <typename T>
-pair<vector<vec4i>, vector<T>> subdivide_quads(
+tuple<vector<vec4i>, vector<T>> subdivide_quads(
     const vector<vec4i>& quads, const vector<T>& vert);
 // Subdivide beziers by splitting each segment in two.
 template <typename T>
-pair<vector<vec4i>, vector<T>> subdivide_beziers(
+tuple<vector<vec4i>, vector<T>> subdivide_beziers(
     const vector<vec4i>& beziers, const vector<T>& vert);
 // Subdivide quads using Carmull-Clark subdivision rules.
 template <typename T>
-pair<vector<vec4i>, vector<T>> subdivide_catmullclark(
+tuple<vector<vec4i>, vector<T>> subdivide_catmullclark(
     const vector<vec4i>& quads, const vector<T>& vert,
     bool lock_boundary = false);
 
 // Weld vertices within a threshold. For noe the implementation is O(n^2).
-pair<vector<vec3f>, vector<int>> weld_vertices(
+tuple<vector<vec3f>, vector<int>> weld_vertices(
     const vector<vec3f>& pos, float threshold);
-pair<vector<vec3i>, vector<vec3f>> weld_triangles(
+tuple<vector<vec3i>, vector<vec3f>> weld_triangles(
     const vector<vec3i>& triangles, const vector<vec3f>& pos,
     float threshold);
-pair<vector<vec4i>, vector<vec3f>> weld_quads(
+tuple<vector<vec4i>, vector<vec3f>> weld_quads(
     const vector<vec4i>& quads, const vector<vec3f>& pos,
     float threshold);
 
@@ -2164,7 +2164,7 @@ inline vector<float> sample_lines_cdf(
     }
     return cdf;
 }
-inline pair<int, float> sample_lines(
+inline tuple<int, float> sample_lines(
     const vector<float>& cdf, float re, float ru) {
     return {sample_discrete(cdf, re), ru};
 }
@@ -2180,7 +2180,7 @@ inline vector<float> sample_triangles_cdf(
     }
     return cdf;
 }
-inline pair<int, vec2f> sample_triangles(
+inline tuple<int, vec2f> sample_triangles(
     const vector<float>& cdf, float re, const vec2f& ruv) {
     return {sample_discrete(cdf, re), sample_triangle(ruv)};
 }
@@ -2196,7 +2196,7 @@ inline vector<float> sample_quads_cdf(
     }
     return cdf;
 }
-inline pair<int, vec2f> sample_quads(
+inline tuple<int, vec2f> sample_quads(
     const vector<float>& cdf, float re, const vec2f& ruv) {
     return {sample_discrete(cdf, re), ruv};
 }
@@ -3421,7 +3421,7 @@ void trace_async_stop(trace_state* state);
 
 // Trace statistics for last run used for fine tuning implementation.
 // For now returns number of paths and number of rays.
-pair<uint64_t, uint64_t> get_trace_stats();
+tuple<uint64_t, uint64_t> get_trace_stats();
 void                          reset_trace_stats();
 
 }  // namespace ygl

--- a/yocto/ygl.h
+++ b/yocto/ygl.h
@@ -329,6 +329,7 @@ using std::tie;
 using std::tuple;
 using std::function;
 using std::runtime_error;
+using std::atomic;
 using namespace std::string_literals;
 
 using byte = unsigned char;

--- a/yocto/yglio.cpp
+++ b/yocto/yglio.cpp
@@ -58,8 +58,8 @@
 
 #include <cstdlib>
 #include <deque>
-#include <regex>
 #include <map>
+#include <regex>
 
 #include <array>
 #include <climits>
@@ -202,8 +202,7 @@ string get_filename(const string& filename_) {
 }
 
 // Replace extension.
-string replace_extension(
-    const string& filename_, const string& ext_) {
+string replace_extension(const string& filename_, const string& ext_) {
     auto filename = normalize_path(filename_);
     auto ext      = normalize_path(ext_);
     if (ext.at(0) == '.') ext = ext.substr(1);
@@ -237,7 +236,7 @@ void log_io_error(const string& fmt, const Args&... args) {
 struct file_stream {
     string filename = "";
     string mode     = "";
-    FILE*       fs       = nullptr;
+    FILE*  fs       = nullptr;
 
     file_stream()                   = default;
     file_stream(const file_stream&) = delete;
@@ -447,8 +446,7 @@ vector<string> get_option_names(const string& name_) {
 
 // add help
 string get_option_usage(const string& name, const string& var,
-    const string& usage, const string& def_,
-    const vector<string>& choices) {
+    const string& usage, const string& def_, const vector<string>& choices) {
     auto def = def_;
     if (def != "") def = "[" + def + "]";
     auto namevar = name;
@@ -481,8 +479,8 @@ void print_cmdline_usage(const cmdline_parser& parser) {
 }
 
 // forward declaration
-bool parse_flag(cmdline_parser& parser, const string& name, bool def,
-    const string& usage);
+bool parse_flag(
+    cmdline_parser& parser, const string& name, bool def, const string& usage);
 
 // check if any error occurred and exit appropriately
 void check_cmdline(cmdline_parser& parser) {
@@ -499,8 +497,8 @@ void check_cmdline(cmdline_parser& parser) {
 }
 
 // Parse a flag. Name should start with either "--" or "-".
-bool parse_flag(cmdline_parser& parser, const string& name, bool def,
-    const string& usage) {
+bool parse_flag(
+    cmdline_parser& parser, const string& name, bool def, const string& usage) {
     parser.usage_opt += get_option_usage(name, "", usage, "", {});
     if (parser.error != "") return def;
     auto names = get_option_names(name);
@@ -576,16 +574,16 @@ string parse_string(cmdline_parser& parser, const string& name,
 
 // Parse an integer, float, string. If name starts with "--" or "-", then it is
 // an option, otherwise it is a position argument.
-bool parse_arg(cmdline_parser& parser, const string& name, bool def,
-    const string& usage) {
+bool parse_arg(
+    cmdline_parser& parser, const string& name, bool def, const string& usage) {
     return parse_flag(parser, name, def, usage);
 }
-string parse_arg(cmdline_parser& parser, const string& name,
-    const string& def, const string& usage, bool req) {
+string parse_arg(cmdline_parser& parser, const string& name, const string& def,
+    const string& usage, bool req) {
     return parse_string(parser, name, def, usage, req, {});
 }
-string parse_arg(cmdline_parser& parser, const string& name,
-    const char* def, const string& usage, bool req) {
+string parse_arg(cmdline_parser& parser, const string& name, const char* def,
+    const string& usage, bool req) {
     return parse_string(parser, name, def, usage, req, {});
 }
 int parse_arg(cmdline_parser& parser, const string& name, int def,
@@ -608,8 +606,8 @@ float parse_arg(cmdline_parser& parser, const string& name, float def,
     }
     return val;
 }
-vec2f parse_arg(cmdline_parser& parser, const string& name,
-    const vec2f& def, const string& usage, bool req) {
+vec2f parse_arg(cmdline_parser& parser, const string& name, const vec2f& def,
+    const string& usage, bool req) {
     auto vals = parse_string(parser, name, to_string(def), usage, req, {});
     auto val  = def;
     if (!parse(vals, val)) {
@@ -618,8 +616,8 @@ vec2f parse_arg(cmdline_parser& parser, const string& name,
     }
     return val;
 }
-vec3f parse_arg(cmdline_parser& parser, const string& name,
-    const vec3f& def, const string& usage, bool req) {
+vec3f parse_arg(cmdline_parser& parser, const string& name, const vec3f& def,
+    const string& usage, bool req) {
     auto vals = parse_string(parser, name, to_string(def), usage, req, {});
     auto val  = def;
     if (!parse(vals, val)) {
@@ -635,9 +633,8 @@ int parse_arge(cmdline_parser& parser, const string& name, int def,
 }
 
 // Parser an argument
-vector<string> parse_args(cmdline_parser& parser,
-    const string& name, const vector<string>& def,
-    const string& usage, bool req) {
+vector<string> parse_args(cmdline_parser& parser, const string& name,
+    const vector<string>& def, const string& usage, bool req) {
     auto defs = string();
     for (auto& d : def) defs += " " + d;
     parser.usage_arg += get_option_usage(name, "", usage, defs, {});
@@ -1332,8 +1329,8 @@ scene* load_scene(
 }
 
 // Save a scene
-bool save_scene(const string& filename, const scene* scn,
-    bool save_textures, bool skip_missing) {
+bool save_scene(const string& filename, const scene* scn, bool save_textures,
+    bool skip_missing) {
     auto ext = get_extension(filename);
     if (ext == "json" || ext == "JSON") {
         return save_json_scene(filename, scn, save_textures, skip_missing);
@@ -1351,8 +1348,8 @@ bool save_scene(const string& filename, const scene* scn,
     }
 }
 
-bool load_scene_textures(scene* scn, const string& dirname,
-    bool skip_missing, bool assign_opacity) {
+bool load_scene_textures(
+    scene* scn, const string& dirname, bool skip_missing, bool assign_opacity) {
     // load images
     for (auto txt : scn->textures) {
         if (txt->path == "" || !empty(txt->imgf) || !empty(txt->imgb)) continue;
@@ -1444,14 +1441,13 @@ bool save_scene_textures(
 namespace ygl {
 
 // Encode in base64
-string base64_encode(
-    unsigned char const* bytes_to_encode, unsigned int in_len) {
+string base64_encode(unsigned char const* bytes_to_encode, unsigned int in_len) {
     static const string base64_chars =
         "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
         "abcdefghijklmnopqrstuvwxyz"
         "0123456789+/";
 
-    string   ret;
+    string        ret;
     int           i = 0;
     int           j = 0;
     unsigned char char_array_3[3];
@@ -1506,7 +1502,7 @@ string base64_decode(string const& encoded_string) {
     int           j      = 0;
     int           in_    = 0;
     unsigned char char_array_4[4], char_array_3[3];
-    string   ret;
+    string        ret;
 
     while (in_len-- && (encoded_string[in_] != '=') &&
            is_base64(encoded_string[in_])) {
@@ -1610,8 +1606,7 @@ bool dump_json_objref(
 
 // Dumps a json value
 template <typename T>
-bool dump_json_objref(
-    json& js, const vector<T*>& val, const vector<T*>& refs) {
+bool dump_json_objref(json& js, const vector<T*>& val, const vector<T*>& refs) {
     js = json::array();
     for (auto v : val) {
         js.push_back({});
@@ -1622,8 +1617,8 @@ bool dump_json_objref(
 
 // Dumps a json value
 template <typename T>
-bool dump_json_objref(json& js, const vector<T*>& val, const char* name,
-    const vector<T*>& refs) {
+bool dump_json_objref(
+    json& js, const vector<T*>& val, const char* name, const vector<T*>& refs) {
     if (val.empty()) return true;
     return dump_json_objref(js[name], val, refs);
 }
@@ -1656,8 +1651,7 @@ bool parse_json_objref(
 
 // Dumps a json value
 template <typename T>
-bool parse_json_objref(
-    const json& js, vector<T*>& val, const vector<T*>& refs) {
+bool parse_json_objref(const json& js, vector<T*>& val, const vector<T*>& refs) {
     if (!js.is_array()) return false;
     for (auto& j : js) {
         val.push_back(nullptr);
@@ -1668,8 +1662,8 @@ bool parse_json_objref(
 
 // Dumps a json value
 template <typename T>
-bool parse_json_objref(const json& js, vector<T*>& val, const char* name,
-    const vector<T*>& refs) {
+bool parse_json_objref(
+    const json& js, vector<T*>& val, const char* name, const vector<T*>& refs) {
     if (!js.count(name)) return true;
     val = {};
     return parse_json_objref(js.at(name), val, refs);
@@ -1705,8 +1699,7 @@ bool dump_json_objarray(
 
 // Dumps a json value
 template <typename T>
-bool parse_json_objarray(
-    const json& js, vector<T*>& val, const scene* scn) {
+bool parse_json_objarray(const json& js, vector<T*>& val, const scene* scn) {
     if (!js.is_array()) return false;
     for (auto& j : js) {
         val.push_back(new T());
@@ -2491,12 +2484,11 @@ bool apply_json_procedural(const json& js, scene* val, const scene* scn) {
             parse_json_object(j, ists.back(), scn);
         }
 
-        auto pos                      = vector<vec3f>();
-        auto norm                     = vector<vec3f>();
-        auto texcoord                 = vector<vec2f>();
-        tie(pos, norm, texcoord) = sample_triangles_points(
-            base->shp->triangles, base->shp->pos, base->shp->norm,
-            base->shp->texcoord, num, seed);
+        auto pos                 = vector<vec3f>();
+        auto norm                = vector<vec3f>();
+        auto texcoord            = vector<vec2f>();
+        tie(pos, norm, texcoord) = sample_triangles_points(base->shp->triangles,
+            base->shp->pos, base->shp->norm, base->shp->texcoord, num, seed);
 
         auto nmap = unordered_map<instance*, int>();
         for (auto ist : ists) nmap[ist] = 0;
@@ -2735,7 +2727,7 @@ inline double parse_double(char*& s) {
     if (exponent) val *= std::pow(10.0, (double)exponent);
     return val;
 }
-inline float       parse_float(char*& s) { return (float)parse_double(s); }
+inline float  parse_float(char*& s) { return (float)parse_double(s); }
 inline string parse_string(char*& s) {
     if (!*s) return "";
     char buf[4096];
@@ -2811,8 +2803,7 @@ inline obj_texture_info parse_obj_texture_info(char*& s) {
 }
 
 // Load obj materials
-bool load_mtl(
-    const string& filename, const obj_callbacks& cb, bool flip_tr) {
+bool load_mtl(const string& filename, const obj_callbacks& cb, bool flip_tr) {
     // open file
     auto fs = open(filename, "rt");
     if (!fs) return false;
@@ -3086,8 +3077,8 @@ scene* load_obj_scene(const string& filename, bool load_textures,
         }
     };
     auto add_instance = [&](scene* scn, const string& objname,
-                            const string& matname,
-                            const string& groupname, bool smoothing) {
+                            const string& matname, const string& groupname,
+                            bool smoothing) {
         if (scn->instances.empty() || objname != scn->instances.back()->name ||
             !is_instance_empty(scn->instances.back())) {
             auto ist = new instance();
@@ -3297,8 +3288,7 @@ scene* load_obj_scene(const string& filename, bool load_textures,
     return scn;
 }
 
-bool save_mtl(
-    const string& filename, const scene* scn, bool flip_tr = true) {
+bool save_mtl(const string& filename, const scene* scn, bool flip_tr = true) {
     // open
     auto fs = open(filename, "wt");
     if (!fs) return false;
@@ -3548,8 +3538,7 @@ bool gltf_to_scene(scene* scn, const json& gltf, const string& dirname) {
                 if (pos == uri.npos) { return false; }
                 // decode
                 auto data_char = base64_decode(uri.substr(pos + 1));
-                data           = vector<unsigned char>(
-                    (unsigned char*)data_char.c_str(),
+                data = vector<unsigned char>((unsigned char*)data_char.c_str(),
                     (unsigned char*)data_char.c_str() + data_char.length());
             } else {
                 auto filename = normalize_path(dirname + "/" + uri);
@@ -3656,8 +3645,7 @@ bool gltf_to_scene(scene* scn, const json& gltf, const string& dirname) {
             compSize = 4;
         }
         if (!stride) stride = compSize * ncomp;
-        auto vals = vector<std::array<double, 4>>(
-            count, {{0.0, 0.0, 0.0, 1.0}});
+        auto vals = vector<std::array<double, 4>>(count, {{0.0, 0.0, 0.0, 1.0}});
         for (auto i = 0; i < count; i++) {
             auto d = data + offset + i * stride;
             for (auto c = 0; c < ncomp; c++) {
@@ -4172,8 +4160,8 @@ bool scene_to_gltf(const scene* scn, json& js) {
         bjs["uri"]        = replace_extension(shp->path, ".bin");
         auto mat_it       = shape_mats.find(shp);
         if (mat_it != shape_mats.end()) pjs["material"] = mat_it->second;
-        auto add_accessor = [&js, &bjs, bid](int count, string type,
-                                bool indices = false) {
+        auto add_accessor = [&js, &bjs, bid](
+                                int count, string type, bool indices = false) {
             auto bytes = count * 4;
             if (type == "VEC2") bytes *= 2;
             if (type == "VEC3") bytes *= 3;
@@ -4347,8 +4335,7 @@ bool pbrt_to_json(const string& filename, json& js) {
         return tok[0] == '-' || tok[0] == '+' || tok[0] == '.' ||
                std::isdigit(tok[0]);
     };
-    auto parse_string = [](const vector<string>& tokens,
-                            int&                           i) -> string {
+    auto parse_string = [](const vector<string>& tokens, int& i) -> string {
         if (tokens[i][0] != '"') throw runtime_error("string expected");
         auto tok = tokens[i++];
         tok      = tok.substr(1, tok.size() - 2);
@@ -4391,8 +4378,8 @@ bool pbrt_to_json(const string& filename, json& js) {
             if (js.at(name).size() == 1) { js.at(name) = js.at(name).at(0); }
         }
     };
-    auto parse_param_numbers = [&](const vector<string>& tokens,
-                                   int& i, json& js) -> void {
+    auto parse_param_numbers = [&](const vector<string>& tokens, int& i,
+                                   json& js) -> void {
         js["values"] = json::array();
         if (tokens[i][0] == '[') i++;
         while (is_number(tokens, i)) {
@@ -4577,10 +4564,9 @@ scene* load_pbrt_scene(
         return vals;
     };
 
-    auto get_scaled_texture =
-        [&txt_map, &get_vec3f](const json& js) -> tuple<vec3f, texture*> {
-        if (js.is_string())
-            return {{1, 1, 1}, txt_map.at(js.get<string>())};
+    auto get_scaled_texture = [&txt_map, &get_vec3f](
+                                  const json& js) -> tuple<vec3f, texture*> {
+        if (js.is_string()) return {{1, 1, 1}, txt_map.at(js.get<string>())};
         return {get_vec3f(js), nullptr};
     };
 
@@ -4687,8 +4673,7 @@ scene* load_pbrt_scene(
                     mat_map[mat->name] = mat;
                 }
                 auto type = "uber"s;
-                if (jcmd.count("type"))
-                    type = jcmd.at("type").get<string>();
+                if (jcmd.count("type")) type = jcmd.at("type").get<string>();
                 if (type == "uber") {
                     if (jcmd.count("Kd"))
                         tie(mat->kd, mat->kd_txt) = get_scaled_texture(
@@ -4700,8 +4685,8 @@ scene* load_pbrt_scene(
                         tie(mat->kt, mat->kt_txt) = get_scaled_texture(
                             jcmd.at("Kt"));
                     if (jcmd.count("opacity")) {
-                        auto op              = vec3f{0, 0, 0};
-                        auto op_txt          = (texture*)nullptr;
+                        auto op         = vec3f{0, 0, 0};
+                        auto op_txt     = (texture*)nullptr;
                         tie(op, op_txt) = get_scaled_texture(
                             jcmd.at("opacity"));
                         mat->op     = (op.x + op.y + op.z) / 3;
@@ -5280,8 +5265,8 @@ bool serialize_bin_handle(
 // Serialize a pointer. It is saved as an integer index (handle) of the array of
 // pointers vec. On loading, the handle is converted back into a pointer.
 template <typename T>
-bool serialize_bin_handle(vector<T*>& vals, const vector<T*>& vec_,
-    file_stream& fs, bool save) {
+bool serialize_bin_handle(
+    vector<T*>& vals, const vector<T*>& vec_, file_stream& fs, bool save) {
     if (save) {
         auto count = (size_t)vals.size();
         if (!serialize_bin_value(count, fs, true)) return false;
@@ -5481,9 +5466,8 @@ namespace ygl {
 
 // Reset mesh data
 void reset_mesh_data(vector<int>& points, vector<vec2i>& lines,
-    vector<vec3i>& triangles, vector<vec3f>& pos,
-    vector<vec3f>& norm, vector<vec2f>& texcoord,
-    vector<vec4f>& color, vector<float>& radius) {
+    vector<vec3i>& triangles, vector<vec3f>& pos, vector<vec3f>& norm,
+    vector<vec2f>& texcoord, vector<vec4f>& color, vector<float>& radius) {
     points    = {};
     lines     = {};
     triangles = {};
@@ -5495,11 +5479,9 @@ void reset_mesh_data(vector<int>& points, vector<vec2i>& lines,
 }
 
 // Load ply mesh
-bool load_mesh(const string& filename, vector<int>& points,
-    vector<vec2i>& lines, vector<vec3i>& triangles,
-    vector<vec3f>& pos, vector<vec3f>& norm,
-    vector<vec2f>& texcoord, vector<vec4f>& color,
-    vector<float>& radius) {
+bool load_mesh(const string& filename, vector<int>& points, vector<vec2i>& lines,
+    vector<vec3i>& triangles, vector<vec3f>& pos, vector<vec3f>& norm,
+    vector<vec2f>& texcoord, vector<vec4f>& color, vector<float>& radius) {
     auto ext = get_extension(filename);
     if (ext == "ply" || ext == "PLY") {
         return load_ply_mesh(filename, points, lines, triangles, pos, norm,
@@ -5666,9 +5648,8 @@ ply_data load_ply(const string& filename) {
 
 // Load ply mesh
 bool load_ply_mesh(const string& filename, vector<int>& points,
-    vector<vec2i>& lines, vector<vec3i>& triangles,
-    vector<vec3f>& pos, vector<vec3f>& norm,
-    vector<vec2f>& texcoord, vector<vec4f>& color,
+    vector<vec2i>& lines, vector<vec3i>& triangles, vector<vec3f>& pos,
+    vector<vec3f>& norm, vector<vec2f>& texcoord, vector<vec4f>& color,
     vector<float>& radius) {
     // clear
     reset_mesh_data(
@@ -5815,9 +5796,8 @@ bool save_ply_mesh(const string& filename, const vector<int>& points,
 
 // Load ply mesh
 bool load_obj_mesh(const string& filename, vector<int>& points,
-    vector<vec2i>& lines, vector<vec3i>& triangles,
-    vector<vec3f>& pos, vector<vec3f>& norm,
-    vector<vec2f>& texcoord, bool flip_texcoord) {
+    vector<vec2i>& lines, vector<vec3i>& triangles, vector<vec3f>& pos,
+    vector<vec3f>& norm, vector<vec2f>& texcoord, bool flip_texcoord) {
     // clear
     auto color  = vector<vec4f>{};
     auto radius = vector<float>{};
@@ -5923,10 +5903,9 @@ void reset_fvmesh_data(vector<vec4i>& quads_pos, vector<vec3f>& pos,
 
 // Load mesh
 bool load_fvmesh(const string& filename, vector<vec4i>& quads_pos,
-    vector<vec3f>& pos, vector<vec4i>& quads_norm,
-    vector<vec3f>& norm, vector<vec4i>& quads_texcoord,
-    vector<vec2f>& texcoord, vector<vec4i>& quads_color,
-    vector<vec4f>& color) {
+    vector<vec3f>& pos, vector<vec4i>& quads_norm, vector<vec3f>& norm,
+    vector<vec4i>& quads_texcoord, vector<vec2f>& texcoord,
+    vector<vec4i>& quads_color, vector<vec4f>& color) {
     auto ext = get_extension(filename);
     if (ext == "obj" || ext == "OBJ") {
         return load_obj_fvmesh(filename, quads_pos, pos, quads_norm, norm,
@@ -5940,10 +5919,9 @@ bool load_fvmesh(const string& filename, vector<vec4i>& quads_pos,
 }
 
 // Save mesh
-bool save_fvmesh(const string& filename,
-    const vector<vec4i>& quads_pos, const vector<vec3f>& pos,
-    const vector<vec4i>& quads_norm, const vector<vec3f>& norm,
-    const vector<vec4i>& quads_texcoord,
+bool save_fvmesh(const string& filename, const vector<vec4i>& quads_pos,
+    const vector<vec3f>& pos, const vector<vec4i>& quads_norm,
+    const vector<vec3f>& norm, const vector<vec4i>& quads_texcoord,
     const vector<vec2f>& texcoord, const vector<vec4i>& quads_color,
     const vector<vec4f>& color, bool ascii) {
     auto ext = get_extension(filename);
@@ -5958,9 +5936,8 @@ bool save_fvmesh(const string& filename,
 
 // Load obj mesh
 bool load_obj_fvmesh(const string& filename, vector<vec4i>& quads_pos,
-    vector<vec3f>& pos, vector<vec4i>& quads_norm,
-    vector<vec3f>& norm, vector<vec4i>& quads_texcoord,
-    vector<vec2f>& texcoord, bool flip_texcoord) {
+    vector<vec3f>& pos, vector<vec4i>& quads_norm, vector<vec3f>& norm,
+    vector<vec4i>& quads_texcoord, vector<vec2f>& texcoord, bool flip_texcoord) {
     // clear
     vector<vec4i> quads_color;
     vector<vec4f> color;
@@ -6056,10 +6033,9 @@ bool load_obj_fvmesh(const string& filename, vector<vec4i>& quads_pos,
 }
 
 // Load ply mesh
-bool save_obj_fvmesh(const string& filename,
-    const vector<vec4i>& quads_pos, const vector<vec3f>& pos,
-    const vector<vec4i>& quads_norm, const vector<vec3f>& norm,
-    const vector<vec4i>& quads_texcoord,
+bool save_obj_fvmesh(const string& filename, const vector<vec4i>& quads_pos,
+    const vector<vec3f>& pos, const vector<vec4i>& quads_norm,
+    const vector<vec3f>& norm, const vector<vec4i>& quads_texcoord,
     const vector<vec2f>& texcoord, bool flip_texcoord) {
     auto fs = open(filename, "wt");
     if (!fs) return false;

--- a/yocto/yglio.cpp
+++ b/yocto/yglio.cpp
@@ -167,10 +167,10 @@ string normalize_path(const string& filename_) {
     for (auto& c : filename)
         if (c == '\\') c = '/';
     if (filename.size() > 1 && filename[0] == '/' && filename[1] == '/')
-        throw std::runtime_error("no absolute paths");
+        throw runtime_error("no absolute paths");
     if (filename.size() > 3 && filename[1] == ':' && filename[2] == '/' &&
         filename[3] == '/')
-        throw std::runtime_error("no absolute paths");
+        throw runtime_error("no absolute paths");
     auto pos = (size_t)0;
     while ((pos = filename.find("//")) != filename.npos)
         filename = filename.substr(0, pos) + filename.substr(pos + 1);
@@ -1263,7 +1263,7 @@ bool save_tonemapped_image(const string& filename, const image<vec4f>& hdr,
 // Resize image.
 image<vec4f> resize_image(const image<vec4f>& img, const vec2i& size_) {
     auto size = size_;
-    if (!size.x && !size.y) throw std::runtime_error("bad image size");
+    if (!size.x && !size.y) throw runtime_error("bad image size");
     if (!size.x)
         size.x = (int)round(width(img) * (size.y / (float)height(img)));
     if (!size.y)
@@ -1835,7 +1835,7 @@ bool apply_json_procedural(const json& js, texture* val, const scene* scn) {
             js.value("lacunarity", 2.0f), js.value("gain", 0.5f),
             js.value("octaves", 6), js.value("wrap", true));
     } else {
-        throw std::runtime_error("unknown texture type " + type);
+        throw runtime_error("unknown texture type " + type);
     }
     if (js.value("bump_to_normal", false)) {
         val->imgf = bump_to_normal_map(val->imgf, js.value("bump_scale", 1.0f));
@@ -1894,7 +1894,7 @@ bool apply_json_procedural(const json& js, voltexture* val, const scene* scn) {
         val->vol = make_test_volume1f(
             size, js.value("scale", 10.0f), js.value("exponent", 6.0f));
     } else {
-        throw std::runtime_error("unknown texture type " + type);
+        throw runtime_error("unknown texture type " + type);
     }
     if (val->path == "") {
         auto ext  = string("vol");
@@ -2124,7 +2124,7 @@ bool apply_json_procedural(const json& js, shape* val, const scene* scn) {
     } else if (type == "suzanne") {
         shp = make_suzanne(js.value("size", 2.0f), true);
     } else {
-        throw std::runtime_error("unknown shape type " + type);
+        throw runtime_error("unknown shape type " + type);
     }
     if (js.value("flipyz", false)) {
         for (auto& p : shp.pos) p = {p.x, p.z, p.y};
@@ -2209,7 +2209,7 @@ bool apply_json_procedural(const json& js, subdiv* val, const scene* scn) {
         shp.quads_pos = qshp.quads;
         shp.pos       = qshp.pos;
     } else {
-        throw std::runtime_error("unknown shape type " + type);
+        throw runtime_error("unknown shape type " + type);
     }
     val->quads_pos      = shp.quads_pos;
     val->pos            = shp.pos;
@@ -2494,7 +2494,7 @@ bool apply_json_procedural(const json& js, scene* val, const scene* scn) {
         auto pos                      = vector<vec3f>();
         auto norm                     = vector<vec3f>();
         auto texcoord                 = vector<vec2f>();
-        std::tie(pos, norm, texcoord) = sample_triangles_points(
+        tie(pos, norm, texcoord) = sample_triangles_points(
             base->shp->triangles, base->shp->pos, base->shp->norm,
             base->shp->texcoord, num, seed);
 
@@ -3107,7 +3107,7 @@ scene* load_obj_scene(const string& filename, bool load_textures,
         if (matname != "") {
             auto it = mmap.find(matname);
             if (it == mmap.end())
-                throw std::runtime_error("missing material " + matname);
+                throw runtime_error("missing material " + matname);
             ist->mat = it->second;
         }
         vert_map.clear();
@@ -3783,7 +3783,7 @@ bool gltf_to_scene(scene* scn, const json& gltf, const string& dirname) {
                         // points
                         printf("points not supported\n");
                     } else {
-                        throw std::runtime_error("unknown primitive type");
+                        throw runtime_error("unknown primitive type");
                     }
                 } else {
                     auto indices = accessor_values(
@@ -3832,7 +3832,7 @@ bool gltf_to_scene(scene* scn, const json& gltf, const string& dirname) {
                         // points
                         printf("points not supported\n");
                     } else {
-                        throw std::runtime_error("unknown primitive type");
+                        throw runtime_error("unknown primitive type");
                     }
                 }
                 auto mat = (gprim.count("material")) ?
@@ -4349,7 +4349,7 @@ bool pbrt_to_json(const string& filename, json& js) {
     };
     auto parse_string = [](const vector<string>& tokens,
                             int&                           i) -> string {
-        if (tokens[i][0] != '"') throw std::runtime_error("string expected");
+        if (tokens[i][0] != '"') throw runtime_error("string expected");
         auto tok = tokens[i++];
         tok      = tok.substr(1, tok.size() - 2);
         if (tok.find('|') != tok.npos) tok = tok.substr(tok.find('|') + 1);
@@ -4374,7 +4374,7 @@ bool pbrt_to_json(const string& filename, json& js) {
                 i++;
                 if (!list) break;
             } else {
-                if (!first && !list) throw std::runtime_error("bad params");
+                if (!first && !list) throw runtime_error("bad params");
                 js.push_back(atof(tokens[i].c_str()));
                 i++;
                 if (!list) break;
@@ -4422,7 +4422,7 @@ bool pbrt_to_json(const string& filename, json& js) {
     auto tokens = split(pbrt);
     auto i      = 0;
     while (i < tokens.size()) {
-        if (!is_cmd(tokens, i)) throw std::runtime_error("command expected");
+        if (!is_cmd(tokens, i)) throw runtime_error("command expected");
         auto& tok   = tokens[i++];
         auto  jcmd  = json::object();
         jcmd["cmd"] = tok;
@@ -4454,7 +4454,7 @@ bool pbrt_to_json(const string& filename, json& js) {
                    tok == "AttributeEnd" || tok == "TransformEnd" ||
                    tok == "ObjectEnd" || tok == "ReverseOrientation") {
         } else {
-            throw std::runtime_error("unsupported command " + tok);
+            throw runtime_error("unsupported command " + tok);
         }
         js.push_back(jcmd);
     }
@@ -4691,18 +4691,18 @@ scene* load_pbrt_scene(
                     type = jcmd.at("type").get<string>();
                 if (type == "uber") {
                     if (jcmd.count("Kd"))
-                        std::tie(mat->kd, mat->kd_txt) = get_scaled_texture(
+                        tie(mat->kd, mat->kd_txt) = get_scaled_texture(
                             jcmd.at("Kd"));
                     if (jcmd.count("Ks"))
-                        std::tie(mat->ks, mat->ks_txt) = get_scaled_texture(
+                        tie(mat->ks, mat->ks_txt) = get_scaled_texture(
                             jcmd.at("Ks"));
                     if (jcmd.count("Kt"))
-                        std::tie(mat->kt, mat->kt_txt) = get_scaled_texture(
+                        tie(mat->kt, mat->kt_txt) = get_scaled_texture(
                             jcmd.at("Kt"));
                     if (jcmd.count("opacity")) {
                         auto op              = vec3f{0, 0, 0};
                         auto op_txt          = (texture*)nullptr;
-                        std::tie(op, op_txt) = get_scaled_texture(
+                        tie(op, op_txt) = get_scaled_texture(
                             jcmd.at("opacity"));
                         mat->op     = (op.x + op.y + op.z) / 3;
                         mat->op_txt = op_txt;
@@ -4711,7 +4711,7 @@ scene* load_pbrt_scene(
                 } else if (type == "matte") {
                     mat->kd = {1, 1, 1};
                     if (jcmd.count("Kd"))
-                        std::tie(mat->kd, mat->kd_txt) = get_scaled_texture(
+                        tie(mat->kd, mat->kd_txt) = get_scaled_texture(
                             jcmd.at("Kd"));
                     mat->rs = 1;
                 } else if (type == "mirror") {
@@ -4725,21 +4725,21 @@ scene* load_pbrt_scene(
                     mat->rs  = 0;
                 } else if (type == "substrate") {
                     if (jcmd.count("Kd"))
-                        std::tie(mat->kd, mat->kd_txt) = get_scaled_texture(
+                        tie(mat->kd, mat->kd_txt) = get_scaled_texture(
                             jcmd.at("Kd"));
                     mat->ks = {0.04f, 0.04f, 0.04f};
                     if (jcmd.count("Ks"))
-                        std::tie(mat->ks, mat->ks_txt) = get_scaled_texture(
+                        tie(mat->ks, mat->ks_txt) = get_scaled_texture(
                             jcmd.at("Ks"));
                     mat->rs = 0;
                 } else if (type == "glass") {
                     mat->ks = {0.04f, 0.04f, 0.04f};
                     mat->kt = {1, 1, 1};
                     if (jcmd.count("Ks"))
-                        std::tie(mat->ks, mat->ks_txt) = get_scaled_texture(
+                        tie(mat->ks, mat->ks_txt) = get_scaled_texture(
                             jcmd.at("Ks"));
                     if (jcmd.count("Kt"))
-                        std::tie(mat->kt, mat->kt_txt) = get_scaled_texture(
+                        tie(mat->kt, mat->kt_txt) = get_scaled_texture(
                             jcmd.at("Kt"));
                     mat->rs = 0;
                 } else if (type == "mix") {
@@ -5578,9 +5578,9 @@ ply_data load_ply(const string& filename) {
                 auto count_type = parse_string(ss);
                 auto elem_type  = parse_string(ss);
                 if (count_type != "uchar" && count_type != "uint8")
-                    throw std::runtime_error("unsupported ply list type");
+                    throw runtime_error("unsupported ply list type");
                 if (elem_type != "int")
-                    throw std::runtime_error("unsupported ply list type");
+                    throw runtime_error("unsupported ply list type");
                 prop.type = ply_type::ply_int_list;
             } else if (type == "float") {
                 prop.type = ply_type::ply_float;

--- a/yocto/yglio.cpp
+++ b/yocto/yglio.cpp
@@ -3689,7 +3689,7 @@ bool gltf_to_scene(scene* scn, const json& gltf, const string& dirname) {
     };
 
     // convert meshes
-    auto meshes = vector<vector<pair<shape*, material*>>>();
+    auto meshes = vector<vector<tuple<shape*, material*>>>();
     if (gltf.count("meshes")) {
         for (auto mid = 0; mid < gltf.at("meshes").size(); mid++) {
             auto& gmesh = gltf.at("meshes").at(mid);
@@ -3903,18 +3903,18 @@ bool gltf_to_scene(scene* scn, const json& gltf, const string& dirname) {
             if (shps.size() == 1) {
                 nde->ist       = new instance();
                 nde->ist->name = nde->name;
-                nde->ist->shp  = shps[0].first;
-                nde->ist->mat  = shps[0].second;
+                nde->ist->shp  = get<0>(shps[0]);
+                nde->ist->mat  = get<1>(shps[0]);
                 scn->instances.push_back(nde->ist);
             } else {
                 for (auto shp : shps) {
                     auto child       = new node();
-                    child->name      = nde->name + "_" + shp.first->name;
+                    child->name      = nde->name + "_" + get<0>(shp)->name;
                     child->parent    = nde;
                     child->ist       = new instance();
                     child->ist->name = child->name;
-                    child->ist->shp  = shp.first;
-                    child->ist->mat  = shp.second;
+                    child->ist->shp  = get<0>(shp);
+                    child->ist->mat  = get<1>(shp);
                     scn->instances.push_back(child->ist);
                 }
             }
@@ -4578,7 +4578,7 @@ scene* load_pbrt_scene(
     };
 
     auto get_scaled_texture =
-        [&txt_map, &get_vec3f](const json& js) -> pair<vec3f, texture*> {
+        [&txt_map, &get_vec3f](const json& js) -> tuple<vec3f, texture*> {
         if (js.is_string())
             return {{1, 1, 1}, txt_map.at(js.get<string>())};
         return {get_vec3f(js), nullptr};

--- a/yocto/yglio.cpp
+++ b/yocto/yglio.cpp
@@ -59,6 +59,7 @@
 #include <cstdlib>
 #include <deque>
 #include <regex>
+#include <map>
 
 #include <array>
 #include <climits>
@@ -100,7 +101,7 @@
 namespace ygl {
 
 // Format duration string from nanoseconds
-std::string format_duration(int64_t duration) {
+string format_duration(int64_t duration) {
     auto elapsed = duration / 1000000;  // milliseconds
     auto hours   = (int)(elapsed / 3600000);
     elapsed %= 3600000;
@@ -113,7 +114,7 @@ std::string format_duration(int64_t duration) {
     return buf;
 }
 // Format a large integer number in human readable form
-std::string format_num(uint64_t num) {
+string format_num(uint64_t num) {
     auto rem = num % 1000;
     auto div = num / 1000;
     if (div > 0) return format_num(div) + "," + std::to_string(rem);
@@ -145,7 +146,7 @@ void log_message(const char* lbl, const char* msg) {
 
 // Configure the logging
 void set_log_console(bool enabled) { _log_console = enabled; }
-void set_log_file(const std::string& filename, bool append) {
+void set_log_file(const string& filename, bool append) {
     if (_log_filestream) {
         fclose(_log_filestream);
         _log_filestream = nullptr;
@@ -161,7 +162,7 @@ void set_log_file(const std::string& filename, bool append) {
 // -----------------------------------------------------------------------------
 namespace ygl {
 
-std::string normalize_path(const std::string& filename_) {
+string normalize_path(const string& filename_) {
     auto filename = filename_;
     for (auto& c : filename)
         if (c == '\\') c = '/';
@@ -177,42 +178,42 @@ std::string normalize_path(const std::string& filename_) {
 }
 
 // Get directory name (not including '/').
-std::string get_dirname(const std::string& filename_) {
+string get_dirname(const string& filename_) {
     auto filename = normalize_path(filename_);
     auto pos      = filename.rfind('/');
-    if (pos == std::string::npos) return "";
+    if (pos == string::npos) return "";
     return filename.substr(0, pos);
 }
 
 // Get extension (not including '.').
-std::string get_extension(const std::string& filename_) {
+string get_extension(const string& filename_) {
     auto filename = normalize_path(filename_);
     auto pos      = filename.rfind('.');
-    if (pos == std::string::npos) return "";
+    if (pos == string::npos) return "";
     return filename.substr(pos + 1);
 }
 
 // Get filename without directory.
-std::string get_filename(const std::string& filename_) {
+string get_filename(const string& filename_) {
     auto filename = normalize_path(filename_);
     auto pos      = filename.rfind('/');
-    if (pos == std::string::npos) return "";
+    if (pos == string::npos) return "";
     return filename.substr(pos + 1);
 }
 
 // Replace extension.
-std::string replace_extension(
-    const std::string& filename_, const std::string& ext_) {
+string replace_extension(
+    const string& filename_, const string& ext_) {
     auto filename = normalize_path(filename_);
     auto ext      = normalize_path(ext_);
     if (ext.at(0) == '.') ext = ext.substr(1);
     auto pos = filename.rfind('.');
-    if (pos == std::string::npos) return filename;
+    if (pos == string::npos) return filename;
     return filename.substr(0, pos) + "." + ext;
 }
 
 // Check if a file can be opened for reading.
-bool exists_file(const std::string& filename) {
+bool exists_file(const string& filename) {
     auto f = fopen(filename.c_str(), "r");
     if (!f) return false;
     fclose(f);
@@ -228,14 +229,14 @@ namespace ygl {
 
 // log io error
 template <typename... Args>
-void log_io_error(const std::string& fmt, const Args&... args) {
+void log_io_error(const string& fmt, const Args&... args) {
     log_error(fmt, args...);
 }
 
 // File stream wrapper
 struct file_stream {
-    std::string filename = "";
-    std::string mode     = "";
+    string filename = "";
+    string mode     = "";
     FILE*       fs       = nullptr;
 
     file_stream()                   = default;
@@ -253,7 +254,7 @@ struct file_stream {
 };
 
 // Opens a file
-file_stream open(const std::string& filename, const std::string& mode) {
+file_stream open(const string& filename, const string& mode) {
     auto fs = fopen(filename.c_str(), mode.c_str());
     if (!fs) {
         log_io_error("cannot open {}", filename);
@@ -283,7 +284,7 @@ size_t get_length(file_stream& fs) {
 }
 
 // Print to file
-bool write_text(file_stream& fs, const std::string& str) {
+bool write_text(file_stream& fs, const string& str) {
     if (!fs) return false;
     if (fprintf(fs.fs, "%s", str.c_str()) < 0) {
         log_io_error("cannot write to {}", fs.filename);
@@ -305,7 +306,7 @@ bool write_value(file_stream& fs, const T& val) {
 
 // Write to file
 template <typename T>
-bool write_values(file_stream& fs, const std::vector<T>& vals) {
+bool write_values(file_stream& fs, const vector<T>& vals) {
     if (!fs) return false;
     if (fwrite(vals.data(), sizeof(T), vals.size(), fs.fs) != vals.size()) {
         log_io_error("cannot write to {}", fs.filename);
@@ -315,7 +316,7 @@ bool write_values(file_stream& fs, const std::vector<T>& vals) {
 }
 
 // Write to file
-bool write_values(file_stream& fs, const std::string& vals) {
+bool write_values(file_stream& fs, const string& vals) {
     if (!fs) return false;
     if (fwrite(vals.data(), 1, vals.size(), fs.fs) != vals.size()) {
         log_io_error("cannot write to {}", fs.filename);
@@ -326,19 +327,19 @@ bool write_values(file_stream& fs, const std::string& vals) {
 
 // Print shortcut
 template <typename... Args>
-bool print(file_stream& fs, const std::string& fmt, const Args&... args) {
+bool print(file_stream& fs, const string& fmt, const Args&... args) {
     if (!fs) return false;
     return write_text(fs, format(fmt, args...));
 }
 
 // Read binary data to fill the whole buffer
-bool read_line(file_stream& fs, std::string& val) {
+bool read_line(file_stream& fs, string& val) {
     if (!fs) return false;
     // TODO: make lkne as large as possible
     val = "";
     char buf[4096];
     if (!fgets(buf, 4096, fs.fs)) return false;
-    val = std::string(buf);
+    val = string(buf);
     return true;
 }
 
@@ -355,7 +356,7 @@ bool read_value(file_stream& fs, T& val) {
 
 // Read binary data to fill the whole buffer
 template <typename T>
-bool read_values(file_stream& fs, std::vector<T>& vals) {
+bool read_values(file_stream& fs, vector<T>& vals) {
     if (!fs) return false;
     if (fread(vals.data(), sizeof(T), vals.size(), fs.fs) != vals.size()) {
         log_io_error("cannot read from {}", fs.filename);
@@ -365,7 +366,7 @@ bool read_values(file_stream& fs, std::vector<T>& vals) {
 }
 
 // Read binary data to fill the whole buffer
-bool read_values(file_stream& fs, std::string& vals) {
+bool read_values(file_stream& fs, string& vals) {
     if (!fs) return false;
     if (fread(vals.data(), 1, vals.size(), fs.fs) != vals.size()) {
         log_io_error("cannot read from {}", fs.filename);
@@ -375,17 +376,17 @@ bool read_values(file_stream& fs, std::string& vals) {
 }
 
 // Load a text file
-std::string load_text(const std::string& filename) {
+string load_text(const string& filename) {
     // https://stackoverflow.com/questions/2602013/read-whole-ascii-file-into-c-stdstring
     auto fs = open(filename, "rb");
     if (!fs) return {};
-    auto buf = std::vector<char>(get_length(fs));
+    auto buf = vector<char>(get_length(fs));
     if (!read_values(fs, buf)) return {};
-    return std::string{buf.begin(), buf.end()};
+    return string{buf.begin(), buf.end()};
 }
 
 // Save a text file
-bool save_text(const std::string& filename, const std::string& str) {
+bool save_text(const string& filename, const string& str) {
     auto fs = open(filename, "wt");
     if (!fs) return false;
     if (!write_text(fs, str)) return false;
@@ -393,17 +394,17 @@ bool save_text(const std::string& filename, const std::string& str) {
 }
 
 // Load a binary file
-std::vector<byte> load_binary(const std::string& filename) {
+vector<byte> load_binary(const string& filename) {
     // https://stackoverflow.com/questions/2602013/read-whole-ascii-file-into-c-stdstring
     auto fs = open(filename, "rb");
     if (!fs) return {};
-    auto data = std::vector<byte>(get_length(fs));
+    auto data = vector<byte>(get_length(fs));
     if (!read_values(fs, data)) return {};
     return data;
 }
 
 // Save a binary file
-bool save_binary(const std::string& filename, const std::vector<byte>& data) {
+bool save_binary(const string& filename, const vector<byte>& data) {
     auto fs = open(filename.c_str(), "wb");
     if (!fs) return false;
     if (!write_values(fs, data)) return false;
@@ -419,7 +420,7 @@ namespace ygl {
 
 // initialize a command line parser
 cmdline_parser make_cmdline_parser(
-    int argc, char** argv, const std::string& usage, const std::string& cmd) {
+    int argc, char** argv, const string& usage, const string& cmd) {
     auto parser      = cmdline_parser();
     parser.args      = {argv + 1, argv + argc};
     parser.usage_cmd = (cmd.empty()) ? argv[0] : cmd;
@@ -428,13 +429,13 @@ cmdline_parser make_cmdline_parser(
 }
 
 // check if option or argument
-bool is_option(const std::string& name) {
+bool is_option(const string& name) {
     return name.size() > 1 && name.front() == '-';
 }
 
 // get names from string
-std::vector<std::string> get_option_names(const std::string& name_) {
-    auto names = std::vector<std::string>();
+vector<string> get_option_names(const string& name_) {
+    auto names = vector<string>();
     auto name  = name_;
     while (name.find(',') != name.npos) {
         names.push_back(name.substr(0, name.find(',')));
@@ -445,16 +446,16 @@ std::vector<std::string> get_option_names(const std::string& name_) {
 }
 
 // add help
-std::string get_option_usage(const std::string& name, const std::string& var,
-    const std::string& usage, const std::string& def_,
-    const std::vector<std::string>& choices) {
+string get_option_usage(const string& name, const string& var,
+    const string& usage, const string& def_,
+    const vector<string>& choices) {
     auto def = def_;
     if (def != "") def = "[" + def + "]";
     auto namevar = name;
     if (var != "") namevar += " " + var;
     char buf[4096];
     sprintf(buf, "  %-24s %s %s\n", namevar.c_str(), usage.c_str(), def.c_str());
-    auto usagelines = std::string(buf);
+    auto usagelines = string(buf);
     if (!choices.empty()) {
         usagelines += "        accepted values:";
         for (auto& c : choices) usagelines += " " + c;
@@ -480,8 +481,8 @@ void print_cmdline_usage(const cmdline_parser& parser) {
 }
 
 // forward declaration
-bool parse_flag(cmdline_parser& parser, const std::string& name, bool def,
-    const std::string& usage);
+bool parse_flag(cmdline_parser& parser, const string& name, bool def,
+    const string& usage);
 
 // check if any error occurred and exit appropriately
 void check_cmdline(cmdline_parser& parser) {
@@ -498,8 +499,8 @@ void check_cmdline(cmdline_parser& parser) {
 }
 
 // Parse a flag. Name should start with either "--" or "-".
-bool parse_flag(cmdline_parser& parser, const std::string& name, bool def,
-    const std::string& usage) {
+bool parse_flag(cmdline_parser& parser, const string& name, bool def,
+    const string& usage) {
     parser.usage_opt += get_option_usage(name, "", usage, "", {});
     if (parser.error != "") return def;
     auto names = get_option_names(name);
@@ -513,9 +514,9 @@ bool parse_flag(cmdline_parser& parser, const std::string& name, bool def,
 }
 
 // Parse an option string. Name should start with "--" or "-".
-std::string parse_option(cmdline_parser& parser, const std::string& name,
-    const std::string& def, const std::string& usage, bool req,
-    const std::vector<std::string>& choices) {
+string parse_option(cmdline_parser& parser, const string& name,
+    const string& def, const string& usage, bool req,
+    const vector<string>& choices) {
     parser.usage_opt += get_option_usage(name, "", usage, def, choices);
     if (parser.error != "") return def;
     auto names = get_option_names(name);
@@ -543,9 +544,9 @@ std::string parse_option(cmdline_parser& parser, const std::string& name,
 }
 
 // Parse an argument string. Name should not start with "--" or "-".
-std::string parse_argument(cmdline_parser& parser, const std::string& name,
-    const std::string& def, const std::string& usage, bool req,
-    const std::vector<std::string>& choices) {
+string parse_argument(cmdline_parser& parser, const string& name,
+    const string& def, const string& usage, bool req,
+    const vector<string>& choices) {
     parser.usage_arg += get_option_usage(name, "", usage, def, choices);
     if (parser.error != "") return def;
     auto pos = std::find_if(parser.args.begin(), parser.args.end(),
@@ -565,9 +566,9 @@ std::string parse_argument(cmdline_parser& parser, const std::string& name,
 }
 
 // Parse a string argument.
-std::string parse_string(cmdline_parser& parser, const std::string& name,
-    const std::string& def, const std::string& usage, bool req,
-    const std::vector<std::string>& choices) {
+string parse_string(cmdline_parser& parser, const string& name,
+    const string& def, const string& usage, bool req,
+    const vector<string>& choices) {
     return is_option(name) ?
                parse_option(parser, name, def, usage, req, choices) :
                parse_argument(parser, name, def, usage, req, choices);
@@ -575,20 +576,20 @@ std::string parse_string(cmdline_parser& parser, const std::string& name,
 
 // Parse an integer, float, string. If name starts with "--" or "-", then it is
 // an option, otherwise it is a position argument.
-bool parse_arg(cmdline_parser& parser, const std::string& name, bool def,
-    const std::string& usage) {
+bool parse_arg(cmdline_parser& parser, const string& name, bool def,
+    const string& usage) {
     return parse_flag(parser, name, def, usage);
 }
-std::string parse_arg(cmdline_parser& parser, const std::string& name,
-    const std::string& def, const std::string& usage, bool req) {
+string parse_arg(cmdline_parser& parser, const string& name,
+    const string& def, const string& usage, bool req) {
     return parse_string(parser, name, def, usage, req, {});
 }
-std::string parse_arg(cmdline_parser& parser, const std::string& name,
-    const char* def, const std::string& usage, bool req) {
+string parse_arg(cmdline_parser& parser, const string& name,
+    const char* def, const string& usage, bool req) {
     return parse_string(parser, name, def, usage, req, {});
 }
-int parse_arg(cmdline_parser& parser, const std::string& name, int def,
-    const std::string& usage, bool req) {
+int parse_arg(cmdline_parser& parser, const string& name, int def,
+    const string& usage, bool req) {
     auto vals = parse_string(parser, name, to_string(def), usage, req, {});
     auto val  = def;
     if (!parse(vals, val)) {
@@ -597,8 +598,8 @@ int parse_arg(cmdline_parser& parser, const std::string& name, int def,
     }
     return val;
 }
-float parse_arg(cmdline_parser& parser, const std::string& name, float def,
-    const std::string& usage, bool req) {
+float parse_arg(cmdline_parser& parser, const string& name, float def,
+    const string& usage, bool req) {
     auto vals = parse_string(parser, name, to_string(def), usage, req, {});
     auto val  = def;
     if (!parse(vals, val)) {
@@ -607,8 +608,8 @@ float parse_arg(cmdline_parser& parser, const std::string& name, float def,
     }
     return val;
 }
-vec2f parse_arg(cmdline_parser& parser, const std::string& name,
-    const vec2f& def, const std::string& usage, bool req) {
+vec2f parse_arg(cmdline_parser& parser, const string& name,
+    const vec2f& def, const string& usage, bool req) {
     auto vals = parse_string(parser, name, to_string(def), usage, req, {});
     auto val  = def;
     if (!parse(vals, val)) {
@@ -617,8 +618,8 @@ vec2f parse_arg(cmdline_parser& parser, const std::string& name,
     }
     return val;
 }
-vec3f parse_arg(cmdline_parser& parser, const std::string& name,
-    const vec3f& def, const std::string& usage, bool req) {
+vec3f parse_arg(cmdline_parser& parser, const string& name,
+    const vec3f& def, const string& usage, bool req) {
     auto vals = parse_string(parser, name, to_string(def), usage, req, {});
     auto val  = def;
     if (!parse(vals, val)) {
@@ -627,17 +628,17 @@ vec3f parse_arg(cmdline_parser& parser, const std::string& name,
     }
     return val;
 }
-int parse_arge(cmdline_parser& parser, const std::string& name, int def,
-    const std::string& usage, const std::vector<std::string>& labels, bool req) {
+int parse_arge(cmdline_parser& parser, const string& name, int def,
+    const string& usage, const vector<string>& labels, bool req) {
     auto val = parse_string(parser, name, labels.at(def), usage, req, labels);
     return (int)(std::find(labels.begin(), labels.end(), val) - labels.begin());
 }
 
 // Parser an argument
-std::vector<std::string> parse_args(cmdline_parser& parser,
-    const std::string& name, const std::vector<std::string>& def,
-    const std::string& usage, bool req) {
-    auto defs = std::string();
+vector<string> parse_args(cmdline_parser& parser,
+    const string& name, const vector<string>& def,
+    const string& usage, bool req) {
+    auto defs = string();
     for (auto& d : def) defs += " " + d;
     parser.usage_arg += get_option_usage(name, "", usage, defs, {});
     if (parser.error != "") return {};
@@ -647,7 +648,7 @@ std::vector<std::string> parse_args(cmdline_parser& parser,
         if (req) parser.error += "missing value for " + name;
         return {};
     }
-    auto val = std::vector<std::string>{pos, parser.args.end()};
+    auto val = vector<string>{pos, parser.args.end()};
     parser.args.erase(pos, parser.args.end());
     return val;
 }
@@ -663,7 +664,7 @@ namespace ygl {
 using json = nlohmann::json;
 
 // Load a JSON object
-json load_json(const std::string& filename) {
+json load_json(const string& filename) {
     auto txt = load_text(filename);
     if (txt.empty()) return {};
     try {
@@ -675,7 +676,7 @@ json load_json(const std::string& filename) {
 }
 
 // Save a JSON object
-bool save_json(const std::string& filename, const json& js) {
+bool save_json(const string& filename, const json& js) {
     auto str = ""s;
     try {
         str = js.dump(4);
@@ -807,7 +808,7 @@ inline void to_json(json& js, const image<T>& val) {
 template <typename T>
 inline void from_json(const json& js, image<T>& val) {
     auto size = js.at("size").get<vec2i>();
-    auto data = js.at("data").get<std::vector<T>>();
+    auto data = js.at("data").get<vector<T>>();
     val       = image<T>{size, data.data()};
 }
 template <typename T>
@@ -819,7 +820,7 @@ inline void to_json(json& js, const volume<T>& val) {
 template <typename T>
 inline void from_json(const json& js, volume<T>& val) {
     auto size = js.at("size").get<vec3i>();
-    auto data = js.at("data").get<std::vector<T>>();
+    auto data = js.at("data").get<vector<T>>();
     val       = volume<T>{size, data.data()};
 }
 
@@ -831,8 +832,8 @@ inline void from_json(const json& js, volume<T>& val) {
 namespace ygl {
 
 // Split a string
-std::vector<std::string> split_string(const std::string& str) {
-    auto ret = std::vector<std::string>();
+vector<string> split_string(const string& str) {
+    auto ret = vector<string>();
     if (str.empty()) return ret;
     auto lpos = (size_t)0;
     while (lpos != str.npos) {
@@ -855,7 +856,7 @@ float* load_pfm(const char* filename, int* w, int* h, int* nc, int req) {
 
     // buffer
     char buf[256];
-    auto toks = std::vector<std::string>();
+    auto toks = vector<string>();
 
     // read magic
     if (!fgets(buf, 256, fs)) return nullptr;
@@ -993,7 +994,7 @@ bool save_pfm(const char* filename, int w, int h, int nc, const float* pixels) {
 }
 
 // load pfm image
-image<vec4f> load_pfm_image4f(const std::string& filename) {
+image<vec4f> load_pfm_image4f(const string& filename) {
     auto ncomp  = 0;
     auto size   = zero2i;
     auto pixels = (vec4f*)load_pfm(
@@ -1006,7 +1007,7 @@ image<vec4f> load_pfm_image4f(const std::string& filename) {
     delete[] pixels;
     return img;
 }
-bool save_pfm_image4f(const std::string& filename, const image<vec4f>& img) {
+bool save_pfm_image4f(const string& filename, const image<vec4f>& img) {
     if (!save_pfm(
             filename.c_str(), width(img), height(img), 4, (float*)data(img))) {
         log_io_error("error saving image {}", filename);
@@ -1016,7 +1017,7 @@ bool save_pfm_image4f(const std::string& filename, const image<vec4f>& img) {
 }
 
 // load exr image weith tiny exr
-image<vec4f> load_exr_image4f(const std::string& filename) {
+image<vec4f> load_exr_image4f(const string& filename) {
     auto size   = zero2i;
     auto pixels = (vec4f*)nullptr;
     if (LoadEXR((float**)&pixels, &size.x, &size.y, filename.c_str(), nullptr) <
@@ -1032,7 +1033,7 @@ image<vec4f> load_exr_image4f(const std::string& filename) {
     free(pixels);
     return img;
 }
-bool save_exr_image4f(const std::string& filename, const image<vec4f>& img) {
+bool save_exr_image4f(const string& filename, const image<vec4f>& img) {
     if (!SaveEXR(
             (float*)data(img), width(img), height(img), 4, filename.c_str())) {
         log_io_error("error saving image {}", filename);
@@ -1042,7 +1043,7 @@ bool save_exr_image4f(const std::string& filename, const image<vec4f>& img) {
 }
 
 // load an image using stbi library
-image<vec4b> load_stb_image4b(const std::string& filename) {
+image<vec4b> load_stb_image4b(const string& filename) {
     auto size   = zero2i;
     auto ncomp  = 0;
     auto pixels = (vec4b*)stbi_load(
@@ -1055,7 +1056,7 @@ image<vec4b> load_stb_image4b(const std::string& filename) {
     free(pixels);
     return img;
 }
-image<vec4f> load_stb_image4f(const std::string& filename) {
+image<vec4f> load_stb_image4f(const string& filename) {
     auto size   = zero2i;
     auto ncomp  = 0;
     auto pixels = (vec4f*)stbi_loadf(
@@ -1070,7 +1071,7 @@ image<vec4f> load_stb_image4f(const std::string& filename) {
 }
 
 // save an image with stbi
-bool save_png_image4b(const std::string& filename, const image<vec4b>& img) {
+bool save_png_image4b(const string& filename, const image<vec4b>& img) {
     if (!stbi_write_png(filename.c_str(), width(img), height(img), 4, data(img),
             width(img) * 4)) {
         log_io_error("error saving image {}", filename);
@@ -1078,7 +1079,7 @@ bool save_png_image4b(const std::string& filename, const image<vec4b>& img) {
     }
     return true;
 }
-bool save_jpg_image4b(const std::string& filename, const image<vec4b>& img) {
+bool save_jpg_image4b(const string& filename, const image<vec4b>& img) {
     if (!stbi_write_jpg(
             filename.c_str(), width(img), height(img), 4, data(img), 75)) {
         log_io_error("error saving image {}", filename);
@@ -1086,7 +1087,7 @@ bool save_jpg_image4b(const std::string& filename, const image<vec4b>& img) {
     }
     return true;
 }
-bool save_tga_image4b(const std::string& filename, const image<vec4b>& img) {
+bool save_tga_image4b(const string& filename, const image<vec4b>& img) {
     if (!stbi_write_tga(
             filename.c_str(), width(img), height(img), 4, data(img))) {
         log_io_error("error saving image {}", filename);
@@ -1094,7 +1095,7 @@ bool save_tga_image4b(const std::string& filename, const image<vec4b>& img) {
     }
     return true;
 }
-bool save_bmp_image4b(const std::string& filename, const image<vec4b>& img) {
+bool save_bmp_image4b(const string& filename, const image<vec4b>& img) {
     if (!stbi_write_bmp(
             filename.c_str(), width(img), height(img), 4, data(img))) {
         log_io_error("error saving image {}", filename);
@@ -1102,7 +1103,7 @@ bool save_bmp_image4b(const std::string& filename, const image<vec4b>& img) {
     }
     return true;
 }
-bool save_hdr_image4f(const std::string& filename, const image<vec4f>& img) {
+bool save_hdr_image4f(const string& filename, const image<vec4f>& img) {
     if (!stbi_write_hdr(
             filename.c_str(), width(img), height(img), 4, (float*)data(img))) {
         log_io_error("error saving image {}", filename);
@@ -1140,13 +1141,13 @@ image<vec4f> load_stbi_image4f_from_memory(const byte* data, int data_size) {
 }
 
 // check hdr extensions
-bool is_hdr_filename(const std::string& filename) {
+bool is_hdr_filename(const string& filename) {
     auto ext = get_extension(filename);
     return ext == "hdr" || ext == "exr" || ext == "pfm";
 }
 
 // Loads an hdr image.
-image<vec4f> load_image4f(const std::string& filename) {
+image<vec4f> load_image4f(const string& filename) {
     auto ext = get_extension(filename);
     if (ext == "exr" || ext == "EXR") {
         return load_exr_image4f(filename);
@@ -1169,7 +1170,7 @@ image<vec4f> load_image4f(const std::string& filename) {
 }
 
 // Saves an hdr image.
-bool save_image4f(const std::string& filename, const image<vec4f>& img) {
+bool save_image4f(const string& filename, const image<vec4f>& img) {
     auto ext = get_extension(filename);
     if (ext == "png" || ext == "PNG") {
         return save_png_image4b(filename, float_to_byte(linear_to_srgb(img)));
@@ -1197,7 +1198,7 @@ image<vec4f> load_image4f_from_memory(const byte* data, int data_size) {
 }
 
 // Loads an hdr image.
-image<vec4b> load_image4b(const std::string& filename) {
+image<vec4b> load_image4b(const string& filename) {
     auto ext = get_extension(filename);
     if (ext == "exr" || ext == "EXR") {
         return float_to_byte(linear_to_srgb(load_exr_image4f(filename)));
@@ -1220,7 +1221,7 @@ image<vec4b> load_image4b(const std::string& filename) {
 }
 
 // Saves an ldr image.
-bool save_image4b(const std::string& filename, const image<vec4b>& img) {
+bool save_image4b(const string& filename, const image<vec4b>& img) {
     auto ext = get_extension(filename);
     if (ext == "png" || ext == "PNG") {
         return save_png_image4b(filename, img);
@@ -1249,7 +1250,7 @@ image<vec4b> load_image4b_from_memory(const byte* data, int data_size) {
 
 // Convenience helper that saves an HDR images as wither a linear HDR file or
 // a tonemapped LDR file depending on file name
-bool save_tonemapped_image(const std::string& filename, const image<vec4f>& hdr,
+bool save_tonemapped_image(const string& filename, const image<vec4f>& hdr,
     float exposure, bool filmic, bool srgb) {
     if (is_hdr_filename(filename)) {
         return save_image4f(filename, hdr);
@@ -1284,7 +1285,7 @@ image<vec4f> resize_image(const image<vec4f>& img, const vec2i& size_) {
 namespace ygl {
 
 // Loads volume data from binary format.
-volume<float> load_volume1f(const std::string& filename) {
+volume<float> load_volume1f(const string& filename) {
     auto fs = open(filename, "r");
     if (!fs) return {};
     auto size = zero3i;
@@ -1295,7 +1296,7 @@ volume<float> load_volume1f(const std::string& filename) {
 }
 
 // Saves volume data in binary format.
-bool save_volume1f(const std::string& filename, const volume<float>& vol) {
+bool save_volume1f(const string& filename, const volume<float>& vol) {
     auto fs = open(filename, "w");
     if (!fs) return false;
     if (!write_value(fs, extents(vol))) return false;
@@ -1312,7 +1313,7 @@ namespace ygl {
 
 // Load a scene
 scene* load_scene(
-    const std::string& filename, bool load_textures, bool skip_missing) {
+    const string& filename, bool load_textures, bool skip_missing) {
     auto ext = get_extension(filename);
     if (ext == "json" || ext == "JSON") {
         return load_json_scene(filename, load_textures, skip_missing);
@@ -1331,7 +1332,7 @@ scene* load_scene(
 }
 
 // Save a scene
-bool save_scene(const std::string& filename, const scene* scn,
+bool save_scene(const string& filename, const scene* scn,
     bool save_textures, bool skip_missing) {
     auto ext = get_extension(filename);
     if (ext == "json" || ext == "JSON") {
@@ -1350,7 +1351,7 @@ bool save_scene(const std::string& filename, const scene* scn,
     }
 }
 
-bool load_scene_textures(scene* scn, const std::string& dirname,
+bool load_scene_textures(scene* scn, const string& dirname,
     bool skip_missing, bool assign_opacity) {
     // load images
     for (auto txt : scn->textures) {
@@ -1378,7 +1379,7 @@ bool load_scene_textures(scene* scn, const std::string& dirname,
 
     // assign opacity texture if needed
     if (assign_opacity) {
-        auto has_opacity = std::unordered_map<texture*, bool>();
+        auto has_opacity = unordered_map<texture*, bool>();
         for (auto& txt : scn->textures) {
             has_opacity[txt] = false;
             for (auto& p : txt->imgf) {
@@ -1406,7 +1407,7 @@ bool load_scene_textures(scene* scn, const std::string& dirname,
 
 // helper to save textures
 bool save_scene_textures(
-    const scene* scn, const std::string& dirname, bool skip_missing) {
+    const scene* scn, const string& dirname, bool skip_missing) {
     // save images
     for (auto txt : scn->textures) {
         if (empty(txt->imgf) && empty(txt->imgb)) continue;
@@ -1443,14 +1444,14 @@ bool save_scene_textures(
 namespace ygl {
 
 // Encode in base64
-std::string base64_encode(
+string base64_encode(
     unsigned char const* bytes_to_encode, unsigned int in_len) {
-    static const std::string base64_chars =
+    static const string base64_chars =
         "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
         "abcdefghijklmnopqrstuvwxyz"
         "0123456789+/";
 
-    std::string   ret;
+    string   ret;
     int           i = 0;
     int           j = 0;
     unsigned char char_array_3[3];
@@ -1490,8 +1491,8 @@ std::string base64_encode(
 }
 
 // Decode from base64
-std::string base64_decode(std::string const& encoded_string) {
-    static const std::string base64_chars =
+string base64_decode(string const& encoded_string) {
+    static const string base64_chars =
         "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
         "abcdefghijklmnopqrstuvwxyz"
         "0123456789+/";
@@ -1505,7 +1506,7 @@ std::string base64_decode(std::string const& encoded_string) {
     int           j      = 0;
     int           in_    = 0;
     unsigned char char_array_4[4], char_array_3[3];
-    std::string   ret;
+    string   ret;
 
     while (in_len-- && (encoded_string[in_] != '=') &&
            is_base64(encoded_string[in_])) {
@@ -1595,14 +1596,14 @@ bool parse_json_value(const json& js, T& val, const char* name, const T& def) {
 
 // Dumps a json value
 template <typename T>
-bool dump_json_objref(json& js, T* val, const std::vector<T*>& refs) {
+bool dump_json_objref(json& js, T* val, const vector<T*>& refs) {
     return dump_json_value(js, val ? val->name : ""s);
 }
 
 // Dumps a json value
 template <typename T>
 bool dump_json_objref(
-    json& js, T* val, const char* name, const std::vector<T*>& refs) {
+    json& js, T* val, const char* name, const vector<T*>& refs) {
     if (!val) return true;
     return dump_json_objref(js[name], val, refs);
 }
@@ -1610,7 +1611,7 @@ bool dump_json_objref(
 // Dumps a json value
 template <typename T>
 bool dump_json_objref(
-    json& js, const std::vector<T*>& val, const std::vector<T*>& refs) {
+    json& js, const vector<T*>& val, const vector<T*>& refs) {
     js = json::array();
     for (auto v : val) {
         js.push_back({});
@@ -1621,15 +1622,15 @@ bool dump_json_objref(
 
 // Dumps a json value
 template <typename T>
-bool dump_json_objref(json& js, const std::vector<T*>& val, const char* name,
-    const std::vector<T*>& refs) {
+bool dump_json_objref(json& js, const vector<T*>& val, const char* name,
+    const vector<T*>& refs) {
     if (val.empty()) return true;
     return dump_json_objref(js[name], val, refs);
 }
 
 // Dumps a json value
 template <typename T>
-bool parse_json_objref(const json& js, T*& val, const std::vector<T*>& refs) {
+bool parse_json_objref(const json& js, T*& val, const vector<T*>& refs) {
     if (!js.is_string()) return false;
     auto name = ""s;
     if (!parse_json_value(js, name)) return false;
@@ -1647,7 +1648,7 @@ bool parse_json_objref(const json& js, T*& val, const std::vector<T*>& refs) {
 // Dumps a json value
 template <typename T>
 bool parse_json_objref(
-    const json& js, T*& val, const char* name, const std::vector<T*>& refs) {
+    const json& js, T*& val, const char* name, const vector<T*>& refs) {
     if (!js.count(name)) return true;
     val = nullptr;
     return parse_json_objref(js.at(name), val, refs);
@@ -1656,7 +1657,7 @@ bool parse_json_objref(
 // Dumps a json value
 template <typename T>
 bool parse_json_objref(
-    const json& js, std::vector<T*>& val, const std::vector<T*>& refs) {
+    const json& js, vector<T*>& val, const vector<T*>& refs) {
     if (!js.is_array()) return false;
     for (auto& j : js) {
         val.push_back(nullptr);
@@ -1667,8 +1668,8 @@ bool parse_json_objref(
 
 // Dumps a json value
 template <typename T>
-bool parse_json_objref(const json& js, std::vector<T*>& val, const char* name,
-    const std::vector<T*>& refs) {
+bool parse_json_objref(const json& js, vector<T*>& val, const char* name,
+    const vector<T*>& refs) {
     if (!js.count(name)) return true;
     val = {};
     return parse_json_objref(js.at(name), val, refs);
@@ -1685,7 +1686,7 @@ bool parse_json_objbegin(const json& js) { return js.is_object(); }
 
 // Dumps a json value
 template <typename T>
-bool dump_json_objarray(json& js, const std::vector<T*>& val, const scene* scn) {
+bool dump_json_objarray(json& js, const vector<T*>& val, const scene* scn) {
     js = json::array();
     for (auto& v : val) {
         js.push_back({});
@@ -1697,7 +1698,7 @@ bool dump_json_objarray(json& js, const std::vector<T*>& val, const scene* scn) 
 // Dumps a json value
 template <typename T>
 bool dump_json_objarray(
-    json& js, const std::vector<T*>& val, const char* name, const scene* scn) {
+    json& js, const vector<T*>& val, const char* name, const scene* scn) {
     if (val.empty()) return true;
     return dump_json_objarray(js[name], val, scn);
 }
@@ -1705,7 +1706,7 @@ bool dump_json_objarray(
 // Dumps a json value
 template <typename T>
 bool parse_json_objarray(
-    const json& js, std::vector<T*>& val, const scene* scn) {
+    const json& js, vector<T*>& val, const scene* scn) {
     if (!js.is_array()) return false;
     for (auto& j : js) {
         val.push_back(new T());
@@ -1717,7 +1718,7 @@ bool parse_json_objarray(
 // Dumps a json value
 template <typename T>
 bool parse_json_objarray(
-    const json& js, std::vector<T*>& val, const char* name, const scene* scn) {
+    const json& js, vector<T*>& val, const char* name, const scene* scn) {
     if (!js.count(name)) return true;
     val = {};
     return parse_json_objarray(js.at(name), val, scn);
@@ -1849,7 +1850,7 @@ bool apply_json_procedural(const json& js, texture* val, const scene* scn) {
         val->imgf = {};
     }
     if (val->path == "") {
-        auto ext  = (is_hdr) ? std::string("hdr") : std::string("png");
+        auto ext  = (is_hdr) ? string("hdr") : string("png");
         val->path = "textures/" + val->name + "." + ext;
     }
     return true;
@@ -1896,7 +1897,7 @@ bool apply_json_procedural(const json& js, voltexture* val, const scene* scn) {
         throw std::runtime_error("unknown texture type " + type);
     }
     if (val->path == "") {
-        auto ext  = std::string("vol");
+        auto ext  = string("vol");
         val->path = "textures/" + val->name + "." + ext;
     }
     return true;
@@ -2380,7 +2381,7 @@ bool parse_json_object(const json& js, node* val, const scene* scn) {
 
 // Serialize enum
 bool dump_json_value(json& js, const animation_type& val) {
-    static auto names = std::map<animation_type, std::string>{
+    static auto names = map<animation_type, string>{
         {animation_type::linear, "linear"},
         {animation_type::step, "step"},
         {animation_type::bezier, "bezier"},
@@ -2391,7 +2392,7 @@ bool dump_json_value(json& js, const animation_type& val) {
 
 // Serialize enum
 bool parse_json_value(const json& js, animation_type& val) {
-    static auto names = std::map<std::string, animation_type>{
+    static auto names = map<string, animation_type>{
         {"linear", animation_type::linear},
         {"step", animation_type::step},
         {"bezier", animation_type::bezier},
@@ -2399,7 +2400,7 @@ bool parse_json_value(const json& js, animation_type& val) {
     auto vals = ""s;
     if (!parse_json_value(js, vals)) return false;
     try {
-        val = names.at(js.get<std::string>());
+        val = names.at(js.get<string>());
     } catch (...) { return false; }
     return true;
 }
@@ -2484,20 +2485,20 @@ bool apply_json_procedural(const json& js, scene* val, const scene* scn) {
         auto  seed = jjs.value("seed", 13);
         auto  base = new instance();
         parse_json_object(jjs.at("base"), base, scn);
-        auto ists = std::vector<instance*>();
+        auto ists = vector<instance*>();
         for (auto& j : jjs.at("instances")) {
             ists.push_back(new instance());
             parse_json_object(j, ists.back(), scn);
         }
 
-        auto pos                      = std::vector<vec3f>();
-        auto norm                     = std::vector<vec3f>();
-        auto texcoord                 = std::vector<vec2f>();
+        auto pos                      = vector<vec3f>();
+        auto norm                     = vector<vec3f>();
+        auto texcoord                 = vector<vec2f>();
         std::tie(pos, norm, texcoord) = sample_triangles_points(
             base->shp->triangles, base->shp->pos, base->shp->norm,
             base->shp->texcoord, num, seed);
 
-        auto nmap = std::unordered_map<instance*, int>();
+        auto nmap = unordered_map<instance*, int>();
         for (auto ist : ists) nmap[ist] = 0;
         auto rng = make_rng(seed, 17);
         for (auto i = 0; i < num; i++) {
@@ -2549,7 +2550,7 @@ bool parse_json_object(const json& js, scene* val) {
 
 // Load a scene in the builtin JSON format.
 scene* load_json_scene(
-    const std::string& filename, bool load_textures, bool skip_missing) {
+    const string& filename, bool load_textures, bool skip_missing) {
     // initialize
     auto scn = new scene();
 
@@ -2583,8 +2584,8 @@ scene* load_json_scene(
     for (auto sbd : scn->subdivs) {
         if (sbd->path == "" || !sbd->pos.empty()) continue;
         auto filename   = normalize_path(dirname + "/" + sbd->path);
-        auto quads_norm = std::vector<vec4i>();
-        auto norm       = std::vector<vec3f>();
+        auto quads_norm = vector<vec4i>();
+        auto norm       = vector<vec3f>();
         if (!load_fvmesh(filename, sbd->quads_pos, sbd->pos, quads_norm, norm,
                 sbd->quads_texcoord, sbd->texcoord, sbd->quads_color,
                 sbd->color)) {
@@ -2610,7 +2611,7 @@ scene* load_json_scene(
 }
 
 // Save a scene in the builtin JSON format.
-bool save_json_scene(const std::string& filename, const scene* scn,
+bool save_json_scene(const string& filename, const scene* scn,
     bool save_textures, bool skip_missing) {
     // save json
     auto js = json();
@@ -2735,7 +2736,7 @@ inline double parse_double(char*& s) {
     return val;
 }
 inline float       parse_float(char*& s) { return (float)parse_double(s); }
-inline std::string parse_string(char*& s) {
+inline string parse_string(char*& s) {
     if (!*s) return "";
     char buf[4096];
     auto valb = buf;
@@ -2788,7 +2789,7 @@ inline obj_texture_info parse_obj_texture_info(char*& s) {
     auto info = obj_texture_info();
 
     // get tokens
-    auto tokens = std::vector<std::string>();
+    auto tokens = vector<string>();
     while (true) {
         auto v = parse_string(s);
         if (v == "") break;
@@ -2800,7 +2801,7 @@ inline obj_texture_info parse_obj_texture_info(char*& s) {
     info.path = normalize_path(tokens.back());
 
     // texture options
-    auto last = std::string();
+    auto last = string();
     for (auto i = 0; i < tokens.size() - 1; i++) {
         if (tokens[i] == "-bm") info.scale = atof(tokens[i + 1].c_str());
         if (tokens[i] == "-clamp") info.clamp = true;
@@ -2811,7 +2812,7 @@ inline obj_texture_info parse_obj_texture_info(char*& s) {
 
 // Load obj materials
 bool load_mtl(
-    const std::string& filename, const obj_callbacks& cb, bool flip_tr) {
+    const string& filename, const obj_callbacks& cb, bool flip_tr) {
     // open file
     auto fs = open(filename, "rt");
     if (!fs) return false;
@@ -2911,7 +2912,7 @@ bool load_mtl(
 }
 
 // Load obj extensions
-bool load_objx(const std::string& filename, const obj_callbacks& cb) {
+bool load_objx(const string& filename, const obj_callbacks& cb) {
     // open file
     auto fs = open(filename, "rt");
     if (!fs) return false;
@@ -2957,7 +2958,7 @@ bool load_objx(const std::string& filename, const obj_callbacks& cb) {
 }
 
 // Load obj scene
-bool load_obj(const std::string& filename, const obj_callbacks& cb,
+bool load_obj(const string& filename, const obj_callbacks& cb,
     bool geometry_only, bool skip_missing, bool flip_texcoord, bool flip_tr) {
     // open file
     auto fs = open(filename, "rt");
@@ -2965,7 +2966,7 @@ bool load_obj(const std::string& filename, const obj_callbacks& cb,
 
     // track vertex size
     auto vert_size = obj_vertex();
-    auto verts     = std::vector<obj_vertex>();  // buffer to avoid reallocation
+    auto verts     = vector<obj_vertex>();  // buffer to avoid reallocation
 
     // read the file line by line
     char buf[4096];
@@ -3041,7 +3042,7 @@ bool load_obj(const std::string& filename, const obj_callbacks& cb,
 }
 
 // Loads an OBJ
-scene* load_obj_scene(const std::string& filename, bool load_textures,
+scene* load_obj_scene(const string& filename, bool load_textures,
     bool skip_missing, bool split_shapes) {
     auto scn = new scene();
 
@@ -3051,9 +3052,9 @@ scene* load_obj_scene(const std::string& filename, bool load_textures,
     auto split_smoothing = split_shapes;
 
     // current parsing values
-    auto matname   = std::string();
-    auto oname     = std::string();
-    auto gname     = std::string();
+    auto matname   = string();
+    auto oname     = string();
+    auto gname     = string();
     auto smoothing = true;
     auto ist       = (instance*)nullptr;
 
@@ -3063,16 +3064,16 @@ scene* load_obj_scene(const std::string& filename, bool load_textures,
     auto otexcoord = std::deque<vec2f>();
 
     // object maps
-    auto tmap = std::unordered_map<std::string, texture*>();
-    auto vmap = std::unordered_map<std::string, voltexture*>();
-    auto mmap = std::unordered_map<std::string, material*>();
+    auto tmap = unordered_map<string, texture*>();
+    auto vmap = unordered_map<string, voltexture*>();
+    auto mmap = unordered_map<string, material*>();
 
     // vertex maps
-    auto name_map     = std::unordered_map<std::string, int>();
-    auto vert_map     = std::unordered_map<obj_vertex, int, obj_vertex_hash>();
-    auto pos_map      = std::unordered_map<int, int>();
-    auto norm_map     = std::unordered_map<int, int>();
-    auto texcoord_map = std::unordered_map<int, int>();
+    auto name_map     = unordered_map<string, int>();
+    auto vert_map     = unordered_map<obj_vertex, int, obj_vertex_hash>();
+    auto pos_map      = unordered_map<int, int>();
+    auto norm_map     = unordered_map<int, int>();
+    auto texcoord_map = unordered_map<int, int>();
 
     // add object if needed
     auto is_instance_empty = [](instance* ist) {
@@ -3084,9 +3085,9 @@ scene* load_obj_scene(const std::string& filename, bool load_textures,
             return true;
         }
     };
-    auto add_instance = [&](scene* scn, const std::string& objname,
-                            const std::string& matname,
-                            const std::string& groupname, bool smoothing) {
+    auto add_instance = [&](scene* scn, const string& objname,
+                            const string& matname,
+                            const string& groupname, bool smoothing) {
         if (scn->instances.empty() || objname != scn->instances.back()->name ||
             !is_instance_empty(scn->instances.back())) {
             auto ist = new instance();
@@ -3147,7 +3148,7 @@ scene* load_obj_scene(const std::string& filename, bool load_textures,
         return txt;
     };
     // Add  vertices to the current shape
-    auto add_verts = [&](const std::vector<obj_vertex>& verts) {
+    auto add_verts = [&](const vector<obj_vertex>& verts) {
         for (auto& vert : verts) {
             auto it = vert_map.find(vert);
             if (it != vert_map.end()) continue;
@@ -3168,43 +3169,43 @@ scene* load_obj_scene(const std::string& filename, bool load_textures,
     cb.vert     = [&](vec3f v) { opos.push_back(v); };
     cb.norm     = [&](vec3f v) { onorm.push_back(v); };
     cb.texcoord = [&](vec2f v) { otexcoord.push_back(v); };
-    cb.face     = [&](const std::vector<obj_vertex>& verts) {
+    cb.face     = [&](const vector<obj_vertex>& verts) {
         add_verts(verts);
         for (auto i = 2; i < verts.size(); i++)
             ist->shp->triangles.push_back({vert_map.at(verts[0]),
                 vert_map.at(verts[i - 1]), vert_map.at(verts[i])});
     };
-    cb.line = [&](const std::vector<obj_vertex>& verts) {
+    cb.line = [&](const vector<obj_vertex>& verts) {
         add_verts(verts);
         for (auto i = 1; i < verts.size(); i++)
             ist->shp->lines.push_back(
                 {vert_map.at(verts[i - 1]), vert_map.at(verts[i])});
     };
-    cb.point = [&](const std::vector<obj_vertex>& verts) {
+    cb.point = [&](const vector<obj_vertex>& verts) {
         add_verts(verts);
         for (auto i = 0; i < verts.size(); i++)
             ist->shp->points.push_back(vert_map.at(verts[i]));
     };
-    cb.object = [&](const std::string& name) {
+    cb.object = [&](const string& name) {
         oname     = name;
         gname     = "";
         matname   = "";
         smoothing = true;
         ist       = add_instance(scn, oname, matname, gname, smoothing);
     };
-    cb.group = [&](const std::string& name) {
+    cb.group = [&](const string& name) {
         gname = name;
         if (split_group) {
             ist = add_instance(scn, oname, matname, gname, smoothing);
         }
     };
-    cb.smoothing = [&](const std::string& name) {
+    cb.smoothing = [&](const string& name) {
         smoothing = (name == "on");
         if (split_smoothing) {
             ist = add_instance(scn, oname, matname, gname, smoothing);
         }
     };
-    cb.usemtl = [&](const std::string& name) {
+    cb.usemtl = [&](const string& name) {
         matname = name;
         if (split_material) {
             ist = add_instance(scn, oname, matname, gname, smoothing);
@@ -3297,7 +3298,7 @@ scene* load_obj_scene(const std::string& filename, bool load_textures,
 }
 
 bool save_mtl(
-    const std::string& filename, const scene* scn, bool flip_tr = true) {
+    const string& filename, const scene* scn, bool flip_tr = true) {
     // open
     auto fs = open(filename, "wt");
     if (!fs) return false;
@@ -3338,7 +3339,7 @@ bool save_mtl(
     return true;
 }
 
-bool save_objx(const std::string& filename, const scene* scn) {
+bool save_objx(const string& filename, const scene* scn) {
     // scene
     auto fs = open(filename, "wt");
     if (!fs) return false;
@@ -3359,7 +3360,7 @@ bool save_objx(const std::string& filename, const scene* scn) {
     return true;
 }
 
-std::string to_string(const obj_vertex& v) {
+string to_string(const obj_vertex& v) {
     auto s = std::to_string(v.pos);
     if (v.texcoord) {
         s += "/" + std::to_string(v.texcoord);
@@ -3371,7 +3372,7 @@ std::string to_string(const obj_vertex& v) {
 }
 
 bool save_obj(
-    const std::string& filename, const scene* scn, bool flip_texcoord = true) {
+    const string& filename, const scene* scn, bool flip_texcoord = true) {
     // scene
     auto fs = open(filename, "wt");
     if (!fs) return false;
@@ -3482,7 +3483,7 @@ bool save_obj(
     return true;
 }
 
-bool save_obj_scene(const std::string& filename, const scene* scn,
+bool save_obj_scene(const string& filename, const scene* scn,
     bool save_textures, bool skip_missing) {
     if (!save_obj(filename, scn, true)) return false;
     if (!scn->materials.empty()) {
@@ -3510,7 +3511,7 @@ bool save_obj_scene(const std::string& filename, const scene* scn,
 // -----------------------------------------------------------------------------
 namespace ygl {
 
-static bool startswith(const std::string& str, const std::string& substr) {
+static bool startswith(const string& str, const string& substr) {
     if (str.length() < substr.length()) return false;
     for (auto i = 0; i < substr.length(); i++)
         if (str[i] != substr[i]) return false;
@@ -3518,7 +3519,7 @@ static bool startswith(const std::string& str, const std::string& substr) {
 }
 
 // convert gltf to scene
-bool gltf_to_scene(scene* scn, const json& gltf, const std::string& dirname) {
+bool gltf_to_scene(scene* scn, const json& gltf, const string& dirname) {
     // convert textures
     if (gltf.count("images")) {
         for (auto iid = 0; iid < gltf.at("images").size(); iid++) {
@@ -3526,14 +3527,14 @@ bool gltf_to_scene(scene* scn, const json& gltf, const std::string& dirname) {
             auto  txt  = new texture();
             txt->name  = gimg.value("name", ""s);
             txt->path  = (startswith(gimg.value("uri", ""s), "data:")) ?
-                            std::string("[glTF-inline].png") :
+                            string("[glTF-inline].png") :
                             gimg.value("uri", ""s);
             scn->textures.push_back(txt);
         }
     }
 
     // load buffers
-    auto bmap = std::vector<std::vector<byte>>();
+    auto bmap = vector<vector<byte>>();
     if (gltf.count("buffers")) {
         bmap.resize(gltf.at("buffers").size());
         for (auto bid = 0; bid < gltf.at("buffers").size(); bid++) {
@@ -3547,7 +3548,7 @@ bool gltf_to_scene(scene* scn, const json& gltf, const std::string& dirname) {
                 if (pos == uri.npos) { return false; }
                 // decode
                 auto data_char = base64_decode(uri.substr(pos + 1));
-                data           = std::vector<unsigned char>(
+                data           = vector<unsigned char>(
                     (unsigned char*)data_char.c_str(),
                     (unsigned char*)data_char.c_str() + data_char.length());
             } else {
@@ -3636,7 +3637,7 @@ bool gltf_to_scene(scene* scn, const json& gltf, const std::string& dirname) {
     // get values from accessors
     auto accessor_values =
         [&gltf, &bmap](const json& gacc,
-            bool normalize = false) -> std::vector<std::array<double, 4>> {
+            bool normalize = false) -> vector<std::array<double, 4>> {
         auto gview  = gltf.at("bufferViews").at(gacc.value("bufferView", -1));
         auto data   = bmap.at(gview.value("buffer", -1)).data();
         auto offset = gacc.value("byteOffset", 0) + gview.value("byteOffset", 0);
@@ -3655,7 +3656,7 @@ bool gltf_to_scene(scene* scn, const json& gltf, const std::string& dirname) {
             compSize = 4;
         }
         if (!stride) stride = compSize * ncomp;
-        auto vals = std::vector<std::array<double, 4>>(
+        auto vals = vector<std::array<double, 4>>(
             count, {{0.0, 0.0, 0.0, 1.0}});
         for (auto i = 0; i < count; i++) {
             auto d = data + offset + i * stride;
@@ -3688,7 +3689,7 @@ bool gltf_to_scene(scene* scn, const json& gltf, const std::string& dirname) {
     };
 
     // convert meshes
-    auto meshes = std::vector<std::vector<std::pair<shape*, material*>>>();
+    auto meshes = vector<vector<pair<shape*, material*>>>();
     if (gltf.count("meshes")) {
         for (auto mid = 0; mid < gltf.at("meshes").size(); mid++) {
             auto& gmesh = gltf.at("meshes").at(mid);
@@ -3698,7 +3699,7 @@ bool gltf_to_scene(scene* scn, const json& gltf, const std::string& dirname) {
                 if (!gprim.count("attributes")) continue;
                 auto shp  = new shape();
                 shp->name = gmesh.value("name", ""s) +
-                            ((sid) ? std::to_string(sid) : std::string());
+                            ((sid) ? std::to_string(sid) : string());
                 sid++;
                 for (json::iterator gattr_it = gprim.at("attributes").begin();
                      gattr_it != gprim.at("attributes").end(); ++gattr_it) {
@@ -3924,9 +3925,9 @@ bool gltf_to_scene(scene* scn, const json& gltf, const std::string& dirname) {
     if (gltf.count("animations")) {
         for (auto& ganm : gltf.at("animations")) {
             auto aid         = 0;
-            auto sampler_map = std::unordered_map<vec2i, int>();
+            auto sampler_map = unordered_map<vec2i, int>();
             for (auto& gchannel : ganm.at("channels")) {
-                auto path_ = gchannel.at("target").at("path").get<std::string>();
+                auto path_ = gchannel.at("target").at("path").get<string>();
                 auto path  = -1;
                 if (path_ == "translation") path = 0;
                 if (path_ == "rotation") path = 1;
@@ -3991,7 +3992,7 @@ bool gltf_to_scene(scene* scn, const json& gltf, const std::string& dirname) {
                             }
                         }
                         if (ncomp) {
-                            auto values = std::vector<float>();
+                            auto values = vector<float>();
                             values.reserve(output_view.size());
                             for (auto i = 0; i < output_view.size(); i++)
                                 values.push_back(output_view.get(i));
@@ -4024,7 +4025,7 @@ bool gltf_to_scene(scene* scn, const json& gltf, const std::string& dirname) {
 
 // Load a scene
 scene* load_gltf_scene(
-    const std::string& filename, bool load_textures, bool skip_missing) {
+    const string& filename, bool load_textures, bool skip_missing) {
     // initialization
     auto scn = new scene();
 
@@ -4086,7 +4087,7 @@ bool scene_to_gltf(const scene* scn, json& js) {
     if (!scn->nodes.empty()) js["nodes"] = json::array();
 
     // convert cameras
-    auto cmap = std::unordered_map<camera*, int>();
+    auto cmap = unordered_map<camera*, int>();
     for (auto cam : scn->cameras) {
         auto cjs    = json();
         cjs["name"] = cam->name;
@@ -4105,7 +4106,7 @@ bool scene_to_gltf(const scene* scn, json& js) {
     }
 
     // textures
-    auto tmap = std::unordered_map<texture*, int>();
+    auto tmap = unordered_map<texture*, int>();
     for (auto& txt : scn->textures) {
         auto tjs = json(), ijs = json();
         tjs["source"] = (int)js["images"].size();
@@ -4116,7 +4117,7 @@ bool scene_to_gltf(const scene* scn, json& js) {
     }
 
     // material
-    auto mmap = std::unordered_map<material*, int>();
+    auto mmap = unordered_map<material*, int>();
     for (auto mat : scn->materials) {
         auto mjs           = json();
         mjs["name"]        = mat->name;
@@ -4155,12 +4156,12 @@ bool scene_to_gltf(const scene* scn, json& js) {
     }
 
     // determine shape materials
-    auto shape_mats = std::unordered_map<shape*, int>();
+    auto shape_mats = unordered_map<shape*, int>();
     for (auto ist : scn->instances)
         if (ist->mat) shape_mats[ist->shp] = mmap.at(ist->mat);
 
     // shapes
-    auto smap = std::unordered_map<shape*, int>();
+    auto smap = unordered_map<shape*, int>();
     for (auto shp : scn->shapes) {
         auto mjs = json(), bjs = json(), pjs = json();
         auto bid          = js["buffers"].size();
@@ -4171,7 +4172,7 @@ bool scene_to_gltf(const scene* scn, json& js) {
         bjs["uri"]        = replace_extension(shp->path, ".bin");
         auto mat_it       = shape_mats.find(shp);
         if (mat_it != shape_mats.end()) pjs["material"] = mat_it->second;
-        auto add_accessor = [&js, &bjs, bid](int count, std::string type,
+        auto add_accessor = [&js, &bjs, bid](int count, string type,
                                 bool indices = false) {
             auto bytes = count * 4;
             if (type == "VEC2") bytes *= 2;
@@ -4220,7 +4221,7 @@ bool scene_to_gltf(const scene* scn, json& js) {
     }
 
     // nodes
-    auto nmap = std::unordered_map<node*, int>();
+    auto nmap = unordered_map<node*, int>();
     for (auto& nde : scn->nodes) {
         auto njs           = json();
         njs["name"]        = nde->name;
@@ -4264,7 +4265,7 @@ bool scene_to_gltf(const scene* scn, json& js) {
 }
 
 // save gltf mesh
-bool save_gltf_mesh(const std::string& filename, const shape* shp) {
+bool save_gltf_mesh(const string& filename, const shape* shp) {
     auto fs = open(filename, "wb");
     if (!fs) return false;
 
@@ -4280,7 +4281,7 @@ bool save_gltf_mesh(const std::string& filename, const shape* shp) {
 }
 
 // Save gltf json
-bool save_gltf_scene(const std::string& filename, const scene* scn,
+bool save_gltf_scene(const string& filename, const scene* scn,
     bool save_textures, bool skip_missing) {
     // save json
     auto js = json();
@@ -4317,9 +4318,9 @@ bool save_gltf_scene(const std::string& filename, const scene* scn,
 namespace ygl {
 
 // convert pbrt to json
-bool pbrt_to_json(const std::string& filename, json& js) {
-    auto split = [](const std::string& str) {
-        auto ret = std::vector<std::string>();
+bool pbrt_to_json(const string& filename, json& js) {
+    auto split = [](const string& str) {
+        auto ret = vector<string>();
         if (str.empty()) return ret;
         auto lpos = (size_t)0;
         while (lpos != str.npos) {
@@ -4335,26 +4336,26 @@ bool pbrt_to_json(const std::string& filename, json& js) {
         return ret;
     };
 
-    auto is_cmd = [](const std::vector<std::string>& tokens, int i) -> bool {
+    auto is_cmd = [](const vector<string>& tokens, int i) -> bool {
         auto& tok = tokens.at(i);
         return !(tok[0] == '[' || tok[0] == ']' || tok[0] == '\"' ||
                  tok[0] == '-' || tok[0] == '+' || tok[0] == '.' ||
                  std::isdigit(tok[0]));
     };
-    auto is_number = [](const std::vector<std::string>& tokens, int i) -> bool {
+    auto is_number = [](const vector<string>& tokens, int i) -> bool {
         auto& tok = tokens.at(i);
         return tok[0] == '-' || tok[0] == '+' || tok[0] == '.' ||
                std::isdigit(tok[0]);
     };
-    auto parse_string = [](const std::vector<std::string>& tokens,
-                            int&                           i) -> std::string {
+    auto parse_string = [](const vector<string>& tokens,
+                            int&                           i) -> string {
         if (tokens[i][0] != '"') throw std::runtime_error("string expected");
         auto tok = tokens[i++];
         tok      = tok.substr(1, tok.size() - 2);
         if (tok.find('|') != tok.npos) tok = tok.substr(tok.find('|') + 1);
         return tok;
     };
-    auto parse_param = [&](const std::vector<std::string>& tokens, int& i,
+    auto parse_param = [&](const vector<string>& tokens, int& i,
                            json& js) -> void {
         auto list = false, first = true;
         while (i < tokens.size()) {
@@ -4380,7 +4381,7 @@ bool pbrt_to_json(const std::string& filename, json& js) {
             }
         }
     };
-    auto parse_param_list = [&](const std::vector<std::string>& tokens, int& i,
+    auto parse_param_list = [&](const vector<string>& tokens, int& i,
                                 json& js) -> void {
         while (i < tokens.size()) {
             if (is_cmd(tokens, i)) break;
@@ -4390,7 +4391,7 @@ bool pbrt_to_json(const std::string& filename, json& js) {
             if (js.at(name).size() == 1) { js.at(name) = js.at(name).at(0); }
         }
     };
-    auto parse_param_numbers = [&](const std::vector<std::string>& tokens,
+    auto parse_param_numbers = [&](const vector<string>& tokens,
                                    int& i, json& js) -> void {
         js["values"] = json::array();
         if (tokens[i][0] == '[') i++;
@@ -4464,7 +4465,7 @@ bool pbrt_to_json(const std::string& filename, json& js) {
 
 // load pbrt scenes
 scene* load_pbrt_scene(
-    const std::string& filename, bool load_textures, bool skip_missing) {
+    const string& filename, bool load_textures, bool skip_missing) {
     // convert to json
     auto js = json();
     try {
@@ -4483,11 +4484,11 @@ scene* load_pbrt_scene(
 
     // parse
     auto scn   = new scene();
-    auto stack = std::vector<stack_item>();
+    auto stack = vector<stack_item>();
     stack.push_back(stack_item());
 
-    auto txt_map = std::map<std::string, texture*>();
-    auto mat_map = std::map<std::string, material*>();
+    auto txt_map = map<string, texture*>();
+    auto mat_map = map<string, material*>();
     auto mid     = 0;
 
     auto get_vec3f = [](const json& js) -> vec3f {
@@ -4535,12 +4536,12 @@ scene* load_pbrt_scene(
         return m;
     };
 
-    auto get_vector_vec3i = [](const json& js) -> std::vector<vec3i> {
+    auto get_vector_vec3i = [](const json& js) -> vector<vec3i> {
         if (!js.is_array() || js.size() % 3) {
             printf("cannot handle vector<vec3f>\n");
             return {};
         }
-        auto vals = std::vector<vec3i>(js.size() / 3);
+        auto vals = vector<vec3i>(js.size() / 3);
         for (auto i = 0; i < vals.size(); i++) {
             vals[i].x = (int)std::round(js.at(i * 3 + 0).get<float>());
             vals[i].y = (int)std::round(js.at(i * 3 + 1).get<float>());
@@ -4549,12 +4550,12 @@ scene* load_pbrt_scene(
         return vals;
     };
 
-    auto get_vector_vec3f = [](const json& js) -> std::vector<vec3f> {
+    auto get_vector_vec3f = [](const json& js) -> vector<vec3f> {
         if (!js.is_array() || js.size() % 3) {
             printf("cannot handle vector<vec3f>\n");
             return {};
         }
-        auto vals = std::vector<vec3f>(js.size() / 3);
+        auto vals = vector<vec3f>(js.size() / 3);
         for (auto i = 0; i < vals.size(); i++) {
             vals[i].x = js.at(i * 3 + 0).get<float>();
             vals[i].y = js.at(i * 3 + 1).get<float>();
@@ -4563,12 +4564,12 @@ scene* load_pbrt_scene(
         return vals;
     };
 
-    auto get_vector_vec2f = [](const json& js) -> std::vector<vec2f> {
+    auto get_vector_vec2f = [](const json& js) -> vector<vec2f> {
         if (!js.is_array() || js.size() % 2) {
             printf("cannot handle vector<vec3f>\n");
             return {};
         }
-        auto vals = std::vector<vec2f>(js.size() / 2);
+        auto vals = vector<vec2f>(js.size() / 2);
         for (auto i = 0; i < vals.size(); i++) {
             vals[i].x = js.at(i * 2 + 0).get<float>();
             vals[i].y = js.at(i * 2 + 1).get<float>();
@@ -4577,17 +4578,17 @@ scene* load_pbrt_scene(
     };
 
     auto get_scaled_texture =
-        [&txt_map, &get_vec3f](const json& js) -> std::pair<vec3f, texture*> {
+        [&txt_map, &get_vec3f](const json& js) -> pair<vec3f, texture*> {
         if (js.is_string())
-            return {{1, 1, 1}, txt_map.at(js.get<std::string>())};
+            return {{1, 1, 1}, txt_map.at(js.get<string>())};
         return {get_vec3f(js), nullptr};
     };
 
     auto use_hierarchy = false;
 
-    std::map<std::string, std::vector<instance*>> objects;
+    map<string, vector<instance*>> objects;
     for (auto& jcmd : js) {
-        auto cmd = jcmd.at("cmd").get<std::string>();
+        auto cmd = jcmd.at("cmd").get<string>();
         if (cmd == "ObjectInstance") {
             use_hierarchy = true;
             break;
@@ -4597,7 +4598,7 @@ scene* load_pbrt_scene(
     auto lid = 0, sid = 0, cid = 0;
     auto cur_object = ""s;
     for (auto& jcmd : js) {
-        auto cmd = jcmd.at("cmd").get<std::string>();
+        auto cmd = jcmd.at("cmd").get<string>();
         if (cmd == "Integrator" || cmd == "Sampler" || cmd == "PixelFilter") {
         } else if (cmd == "Transform") {
             stack.back().frame = get_mat4f(jcmd.at("values"));
@@ -4633,7 +4634,7 @@ scene* load_pbrt_scene(
             cam->focus   = stack.back().focus;
             auto aspect  = stack.back().aspect;
             auto fovy    = 1.0f;
-            auto type    = jcmd.at("type").get<std::string>();
+            auto type    = jcmd.at("type").get<string>();
             if (type == "perspective") {
                 fovy = jcmd.at("fov").get<float>() * pif / 180;
             } else {
@@ -4643,7 +4644,7 @@ scene* load_pbrt_scene(
             scn->cameras.push_back(cam);
         } else if (cmd == "Texture") {
             auto found = false;
-            auto name  = jcmd.at("name").get<std::string>();
+            auto name  = jcmd.at("name").get<string>();
             for (auto& txt : scn->textures) {
                 if (txt->name == name) {
                     found = true;
@@ -4653,11 +4654,11 @@ scene* load_pbrt_scene(
             if (!found) {
                 auto txt = new texture();
                 scn->textures.push_back(txt);
-                txt->name          = jcmd.at("name").get<std::string>();
+                txt->name          = jcmd.at("name").get<string>();
                 txt_map[txt->name] = txt;
-                auto type          = jcmd.at("type").get<std::string>();
+                auto type          = jcmd.at("type").get<string>();
                 if (type == "imagemap") {
-                    txt->path = jcmd.at("filename").get<std::string>();
+                    txt->path = jcmd.at("filename").get<string>();
                     if (get_extension(txt->path) == "pfm")
                         txt->path = replace_extension(txt->path, ".hdr");
                 } else {
@@ -4667,7 +4668,7 @@ scene* load_pbrt_scene(
         } else if (cmd == "MakeNamedMaterial" || cmd == "Material") {
             auto found = false;
             if (cmd == "MakeNamedMaterial") {
-                auto name = jcmd.at("name").get<std::string>();
+                auto name = jcmd.at("name").get<string>();
                 for (auto mat : scn->materials) {
                     if (mat->name == name) {
                         found = true;
@@ -4682,12 +4683,12 @@ scene* load_pbrt_scene(
                     mat->name        = "unnamed_mat" + std::to_string(mid++);
                     stack.back().mat = mat;
                 } else {
-                    mat->name          = jcmd.at("name").get<std::string>();
+                    mat->name          = jcmd.at("name").get<string>();
                     mat_map[mat->name] = mat;
                 }
                 auto type = "uber"s;
                 if (jcmd.count("type"))
-                    type = jcmd.at("type").get<std::string>();
+                    type = jcmd.at("type").get<string>();
                 if (type == "uber") {
                     if (jcmd.count("Kd"))
                         std::tie(mat->kd, mat->kd_txt) = get_scaled_texture(
@@ -4744,7 +4745,7 @@ scene* load_pbrt_scene(
                 } else if (type == "mix") {
                     printf("mix material not properly supported\n");
                     if (jcmd.count("namedmaterial1")) {
-                        auto mat1 = jcmd.at("namedmaterial1").get<std::string>();
+                        auto mat1 = jcmd.at("namedmaterial1").get<string>();
                         auto saved_name = mat->name;
                         *mat            = *mat_map.at(mat1);
                         mat->name       = saved_name;
@@ -4777,7 +4778,7 @@ scene* load_pbrt_scene(
                 }
             }
         } else if (cmd == "NamedMaterial") {
-            stack.back().mat = mat_map.at(jcmd.at("name").get<std::string>());
+            stack.back().mat = mat_map.at(jcmd.at("name").get<string>());
             if (stack.back().light_mat) {
                 auto mat = new material(*stack.back().mat);
                 mat->name += "_" + std::to_string(lid++);
@@ -4788,9 +4789,9 @@ scene* load_pbrt_scene(
             }
         } else if (cmd == "Shape") {
             auto shp  = new shape();
-            auto type = jcmd.at("type").get<std::string>();
+            auto type = jcmd.at("type").get<string>();
             if (type == "plymesh") {
-                auto filename = jcmd.at("filename").get<std::string>();
+                auto filename = jcmd.at("filename").get<string>();
                 shp->name     = get_filename(filename);
                 shp->path     = filename;
                 if (!load_ply_mesh(dirname_ + "/" + filename, shp->points,
@@ -4851,8 +4852,8 @@ scene* load_pbrt_scene(
                 scn->instances.push_back(ist);
             }
         } else if (cmd == "ObjectInstance") {
-            static auto instances = std::map<std::string, int>();
-            auto        name      = jcmd.at("name").get<std::string>();
+            static auto instances = map<string, int>();
+            auto        name      = jcmd.at("name").get<string>();
             auto&       object    = objects.at(name);
             for (auto shp : object) {
                 instances[shp->name] += 1;
@@ -4864,7 +4865,7 @@ scene* load_pbrt_scene(
                 scn->instances.push_back(ist);
             }
         } else if (cmd == "AreaLightSource") {
-            auto type = jcmd.at("type").get<std::string>();
+            auto type = jcmd.at("type").get<string>();
             if (type == "diffuse") {
                 auto lmat              = new material();
                 lmat->ke               = get_vec3f(jcmd.at("L"));
@@ -4873,7 +4874,7 @@ scene* load_pbrt_scene(
                 printf("%s area light not supported\n", type.c_str());
             }
         } else if (cmd == "LightSource") {
-            auto type = jcmd.at("type").get<std::string>();
+            auto type = jcmd.at("type").get<string>();
             if (type == "infinite") {
                 auto env  = new environment();
                 env->name = "env" + std::to_string(lid++);
@@ -4885,7 +4886,7 @@ scene* load_pbrt_scene(
                 if (jcmd.count("scale")) env->ke *= get_vec3f(jcmd.at("scale"));
                 if (jcmd.count("mapname")) {
                     auto txt  = new texture();
-                    txt->path = jcmd.at("mapname").get<std::string>();
+                    txt->path = jcmd.at("mapname").get<string>();
                     txt->name = env->name;
                     scn->textures.push_back(txt);
                     env->ke_txt = txt;
@@ -4930,7 +4931,7 @@ scene* load_pbrt_scene(
         } else if (cmd == "AttributeBegin") {
             stack.push_back(stack.back());
         } else if (cmd == "ObjectBegin") {
-            auto name     = jcmd.at("name").get<std::string>();
+            auto name     = jcmd.at("name").get<string>();
             cur_object    = name;
             objects[name] = {};
         } else if (cmd == "ObjectEnd") {
@@ -4979,7 +4980,7 @@ scene* load_pbrt_scene(
 }
 
 // Convert a scene to pbrt format
-bool save_pbrt(const std::string& filename, const scene* scn) {
+bool save_pbrt(const string& filename, const scene* scn) {
     auto fs = open(filename, "wt");
     if (!fs) return false;
 
@@ -5082,7 +5083,7 @@ WorldEnd
 }
 
 // Save a pbrt scene
-bool save_pbrt_scene(const std::string& filename, const scene* scn,
+bool save_pbrt_scene(const string& filename, const scene* scn,
     bool save_textures, bool skip_missing) {
     // save json
     if (!save_pbrt(filename, scn)) return false;
@@ -5142,9 +5143,9 @@ bool serialize_bin_value(T& val, file_stream& fs, bool save) {
     }
 }
 
-// Serialize std::vector
+// Serialize vector
 template <typename T>
-bool serialize_bin_value(std::vector<T>& vec, file_stream& fs, bool save) {
+bool serialize_bin_value(vector<T>& vec, file_stream& fs, bool save) {
     if (save) {
         auto count = (size_t)vec.size();
         if (!write_value(fs, count)) return false;
@@ -5153,14 +5154,14 @@ bool serialize_bin_value(std::vector<T>& vec, file_stream& fs, bool save) {
     } else {
         auto count = (size_t)0;
         if (!read_value(fs, count)) return false;
-        vec = std::vector<T>(count);
+        vec = vector<T>(count);
         if (!read_values(fs, vec)) return false;
         return true;
     }
 }
 
-// Serialize std::string
-bool serialize_bin_value(std::string& vec, file_stream& fs, bool save) {
+// Serialize string
+bool serialize_bin_value(string& vec, file_stream& fs, bool save) {
     if (save) {
         auto count = (size_t)vec.size();
         if (!write_value(fs, count)) return false;
@@ -5169,7 +5170,7 @@ bool serialize_bin_value(std::string& vec, file_stream& fs, bool save) {
     } else {
         auto count = (size_t)0;
         if (!read_value(fs, count)) return false;
-        vec = std::string(count, ' ');
+        vec = string(count, ' ');
         if (!read_values(fs, vec)) return false;
         return true;
     }
@@ -5209,9 +5210,9 @@ bool serialize_bin_value(volume<T>& vol, file_stream& fs, bool save) {
     }
 }
 
-// Serialize std::vector of pointers
+// Serialize vector of pointers
 template <typename T>
-bool serialize_bin_object(std::vector<T*>& vec, file_stream& fs, bool save) {
+bool serialize_bin_object(vector<T*>& vec, file_stream& fs, bool save) {
     if (save) {
         auto count = (size_t)vec.size();
         if (!serialize_bin_value(count, fs, true)) return false;
@@ -5222,7 +5223,7 @@ bool serialize_bin_object(std::vector<T*>& vec, file_stream& fs, bool save) {
     } else {
         auto count = (size_t)0;
         if (!serialize_bin_value(count, fs, false)) return false;
-        vec = std::vector<T*>(count);
+        vec = vector<T*>(count);
         for (auto i = 0; i < vec.size(); ++i) {
             vec[i] = new T();
             if (!serialize_bin_object(vec[i], fs, false)) return false;
@@ -5231,10 +5232,10 @@ bool serialize_bin_object(std::vector<T*>& vec, file_stream& fs, bool save) {
     }
 }
 
-// Serialize std::vector of pointers
+// Serialize vector of pointers
 template <typename T>
 bool serialize_bin_object(
-    std::vector<T*>& vec, const scene* scn, file_stream& fs, bool save) {
+    vector<T*>& vec, const scene* scn, file_stream& fs, bool save) {
     if (save) {
         auto count = (size_t)vec.size();
         if (!serialize_bin_value(count, fs, true)) return false;
@@ -5245,7 +5246,7 @@ bool serialize_bin_object(
     } else {
         auto count = (size_t)0;
         if (!serialize_bin_value(count, fs, false)) return false;
-        vec = std::vector<T*>(count);
+        vec = vector<T*>(count);
         for (auto i = 0; i < vec.size(); ++i) {
             vec[i] = new T();
             if (!serialize_bin_object(vec[i], scn, fs, false)) return false;
@@ -5258,7 +5259,7 @@ bool serialize_bin_object(
 // pointers vec. On loading, the handle is converted back into a pointer.
 template <typename T>
 bool serialize_bin_handle(
-    T*& val, const std::vector<T*>& vec, file_stream& fs, bool save) {
+    T*& val, const vector<T*>& vec, file_stream& fs, bool save) {
     if (save) {
         auto handle = -1;
         for (auto i = 0; i < vec.size(); ++i)
@@ -5279,7 +5280,7 @@ bool serialize_bin_handle(
 // Serialize a pointer. It is saved as an integer index (handle) of the array of
 // pointers vec. On loading, the handle is converted back into a pointer.
 template <typename T>
-bool serialize_bin_handle(std::vector<T*>& vals, const std::vector<T*>& vec_,
+bool serialize_bin_handle(vector<T*>& vals, const vector<T*>& vec_,
     file_stream& fs, bool save) {
     if (save) {
         auto count = (size_t)vals.size();
@@ -5290,7 +5291,7 @@ bool serialize_bin_handle(std::vector<T*>& vals, const std::vector<T*>& vec_,
     } else {
         auto count = (size_t)0;
         if (!serialize_bin_value(count, fs, false)) return false;
-        vals = std::vector<T*>(count);
+        vals = vector<T*>(count);
         for (auto i = 0; i < vals.size(); ++i) {
             if (!serialize_bin_handle(vals[i], vec_, fs, false)) return false;
         }
@@ -5454,7 +5455,7 @@ bool serialize_scene(scene* scn, file_stream& fs, bool save) {
 
 // Load/save a binary dump useful for very fast scene IO.
 scene* load_ybin_scene(
-    const std::string& filename, bool load_textures, bool skip_missing) {
+    const string& filename, bool load_textures, bool skip_missing) {
     auto fs = open(filename, "rb");
     if (!fs) return nullptr;
     auto scn = new scene();
@@ -5463,7 +5464,7 @@ scene* load_ybin_scene(
 }
 
 // Load/save a binary dump useful for very fast scene IO.
-bool save_ybin_scene(const std::string& filename, const scene* scn,
+bool save_ybin_scene(const string& filename, const scene* scn,
     bool save_textures, bool skip_missing) {
     auto fs = open(filename, "wb");
     if (!fs) return false;
@@ -5479,10 +5480,10 @@ bool save_ybin_scene(const std::string& filename, const scene* scn,
 namespace ygl {
 
 // Reset mesh data
-void reset_mesh_data(std::vector<int>& points, std::vector<vec2i>& lines,
-    std::vector<vec3i>& triangles, std::vector<vec3f>& pos,
-    std::vector<vec3f>& norm, std::vector<vec2f>& texcoord,
-    std::vector<vec4f>& color, std::vector<float>& radius) {
+void reset_mesh_data(vector<int>& points, vector<vec2i>& lines,
+    vector<vec3i>& triangles, vector<vec3f>& pos,
+    vector<vec3f>& norm, vector<vec2f>& texcoord,
+    vector<vec4f>& color, vector<float>& radius) {
     points    = {};
     lines     = {};
     triangles = {};
@@ -5494,11 +5495,11 @@ void reset_mesh_data(std::vector<int>& points, std::vector<vec2i>& lines,
 }
 
 // Load ply mesh
-bool load_mesh(const std::string& filename, std::vector<int>& points,
-    std::vector<vec2i>& lines, std::vector<vec3i>& triangles,
-    std::vector<vec3f>& pos, std::vector<vec3f>& norm,
-    std::vector<vec2f>& texcoord, std::vector<vec4f>& color,
-    std::vector<float>& radius) {
+bool load_mesh(const string& filename, vector<int>& points,
+    vector<vec2i>& lines, vector<vec3i>& triangles,
+    vector<vec3f>& pos, vector<vec3f>& norm,
+    vector<vec2f>& texcoord, vector<vec4f>& color,
+    vector<float>& radius) {
     auto ext = get_extension(filename);
     if (ext == "ply" || ext == "PLY") {
         return load_ply_mesh(filename, points, lines, triangles, pos, norm,
@@ -5514,11 +5515,11 @@ bool load_mesh(const std::string& filename, std::vector<int>& points,
 }
 
 // Save ply mesh
-bool save_mesh(const std::string& filename, const std::vector<int>& points,
-    const std::vector<vec2i>& lines, const std::vector<vec3i>& triangles,
-    const std::vector<vec3f>& pos, const std::vector<vec3f>& norm,
-    const std::vector<vec2f>& texcoord, const std::vector<vec4f>& color,
-    const std::vector<float>& radius, bool ascii) {
+bool save_mesh(const string& filename, const vector<int>& points,
+    const vector<vec2i>& lines, const vector<vec3i>& triangles,
+    const vector<vec3f>& pos, const vector<vec3f>& norm,
+    const vector<vec2f>& texcoord, const vector<vec4f>& color,
+    const vector<float>& radius, bool ascii) {
     auto ext = get_extension(filename);
     if (ext == "ply" || ext == "PLY") {
         return save_ply_mesh(filename, points, lines, triangles, pos, norm,
@@ -5543,7 +5544,7 @@ void normalize_ply_line(char* s) {
 }
 
 // Load ply mesh
-ply_data load_ply(const std::string& filename) {
+ply_data load_ply(const string& filename) {
     // open file
     auto fs = open(filename, "rb");
     if (!fs) return {};
@@ -5664,11 +5665,11 @@ ply_data load_ply(const std::string& filename) {
 }
 
 // Load ply mesh
-bool load_ply_mesh(const std::string& filename, std::vector<int>& points,
-    std::vector<vec2i>& lines, std::vector<vec3i>& triangles,
-    std::vector<vec3f>& pos, std::vector<vec3f>& norm,
-    std::vector<vec2f>& texcoord, std::vector<vec4f>& color,
-    std::vector<float>& radius) {
+bool load_ply_mesh(const string& filename, vector<int>& points,
+    vector<vec2i>& lines, vector<vec3i>& triangles,
+    vector<vec3f>& pos, vector<vec3f>& norm,
+    vector<vec2f>& texcoord, vector<vec4f>& color,
+    vector<float>& radius) {
     // clear
     reset_mesh_data(
         points, lines, triangles, pos, norm, texcoord, color, radius);
@@ -5732,11 +5733,11 @@ bool load_ply_mesh(const std::string& filename, std::vector<int>& points,
 }
 
 // Save ply mesh
-bool save_ply_mesh(const std::string& filename, const std::vector<int>& points,
-    const std::vector<vec2i>& lines, const std::vector<vec3i>& triangles,
-    const std::vector<vec3f>& pos, const std::vector<vec3f>& norm,
-    const std::vector<vec2f>& texcoord, const std::vector<vec4f>& color,
-    const std::vector<float>& radius, bool ascii) {
+bool save_ply_mesh(const string& filename, const vector<int>& points,
+    const vector<vec2i>& lines, const vector<vec3i>& triangles,
+    const vector<vec3f>& pos, const vector<vec3f>& norm,
+    const vector<vec2f>& texcoord, const vector<vec4f>& color,
+    const vector<float>& radius, bool ascii) {
     auto fs = open(filename, "wb");
     if (!fs) return false;
 
@@ -5813,13 +5814,13 @@ bool save_ply_mesh(const std::string& filename, const std::vector<int>& points,
 }
 
 // Load ply mesh
-bool load_obj_mesh(const std::string& filename, std::vector<int>& points,
-    std::vector<vec2i>& lines, std::vector<vec3i>& triangles,
-    std::vector<vec3f>& pos, std::vector<vec3f>& norm,
-    std::vector<vec2f>& texcoord, bool flip_texcoord) {
+bool load_obj_mesh(const string& filename, vector<int>& points,
+    vector<vec2i>& lines, vector<vec3i>& triangles,
+    vector<vec3f>& pos, vector<vec3f>& norm,
+    vector<vec2f>& texcoord, bool flip_texcoord) {
     // clear
-    auto color  = std::vector<vec4f>{};
-    auto radius = std::vector<float>{};
+    auto color  = vector<vec4f>{};
+    auto radius = vector<float>{};
     reset_mesh_data(
         points, lines, triangles, pos, norm, texcoord, color, radius);
 
@@ -5829,10 +5830,10 @@ bool load_obj_mesh(const std::string& filename, std::vector<int>& points,
     auto otexcoord = std::deque<vec2f>();
 
     // vertex maps
-    auto vert_map = std::unordered_map<obj_vertex, int, obj_vertex_hash>();
+    auto vert_map = unordered_map<obj_vertex, int, obj_vertex_hash>();
 
     // Add  vertices to the current shape
-    auto add_verts = [&](const std::vector<obj_vertex>& verts) {
+    auto add_verts = [&](const vector<obj_vertex>& verts) {
         for (auto& vert : verts) {
             auto it = vert_map.find(vert);
             if (it != vert_map.end()) continue;
@@ -5849,18 +5850,18 @@ bool load_obj_mesh(const std::string& filename, std::vector<int>& points,
     cb.vert     = [&](vec3f v) { opos.push_back(v); };
     cb.norm     = [&](vec3f v) { onorm.push_back(v); };
     cb.texcoord = [&](vec2f v) { otexcoord.push_back(v); };
-    cb.face     = [&](const std::vector<obj_vertex>& verts) {
+    cb.face     = [&](const vector<obj_vertex>& verts) {
         add_verts(verts);
         for (auto i = 2; i < verts.size(); i++)
             triangles.push_back({vert_map.at(verts[0]),
                 vert_map.at(verts[i - 1]), vert_map.at(verts[i])});
     };
-    cb.line = [&](const std::vector<obj_vertex>& verts) {
+    cb.line = [&](const vector<obj_vertex>& verts) {
         add_verts(verts);
         for (auto i = 1; i < verts.size(); i++)
             lines.push_back({vert_map.at(verts[i - 1]), vert_map.at(verts[i])});
     };
-    cb.point = [&](const std::vector<obj_vertex>& verts) {
+    cb.point = [&](const vector<obj_vertex>& verts) {
         add_verts(verts);
         for (auto i = 0; i < verts.size(); i++)
             points.push_back(vert_map.at(verts[i]));
@@ -5871,10 +5872,10 @@ bool load_obj_mesh(const std::string& filename, std::vector<int>& points,
 }
 
 // Load ply mesh
-bool save_obj_mesh(const std::string& filename, const std::vector<int>& points,
-    const std::vector<vec2i>& lines, const std::vector<vec3i>& triangles,
-    const std::vector<vec3f>& pos, const std::vector<vec3f>& norm,
-    const std::vector<vec2f>& texcoord, bool flip_texcoord) {
+bool save_obj_mesh(const string& filename, const vector<int>& points,
+    const vector<vec2i>& lines, const vector<vec3i>& triangles,
+    const vector<vec3f>& pos, const vector<vec3f>& norm,
+    const vector<vec2f>& texcoord, bool flip_texcoord) {
     auto fs = open(filename, "wt");
     if (!fs) return false;
 
@@ -5906,10 +5907,10 @@ bool save_obj_mesh(const std::string& filename, const std::vector<int>& points,
 namespace ygl {
 
 // Reset mesh data
-void reset_fvmesh_data(std::vector<vec4i>& quads_pos, std::vector<vec3f>& pos,
-    std::vector<vec4i>& quads_norm, std::vector<vec3f>& norm,
-    std::vector<vec4i>& quads_texcoord, std::vector<vec2f>& texcoord,
-    std::vector<vec4i>& quads_color, std::vector<vec4f>& color) {
+void reset_fvmesh_data(vector<vec4i>& quads_pos, vector<vec3f>& pos,
+    vector<vec4i>& quads_norm, vector<vec3f>& norm,
+    vector<vec4i>& quads_texcoord, vector<vec2f>& texcoord,
+    vector<vec4i>& quads_color, vector<vec4f>& color) {
     quads_pos      = {};
     pos            = {};
     quads_norm     = {};
@@ -5921,11 +5922,11 @@ void reset_fvmesh_data(std::vector<vec4i>& quads_pos, std::vector<vec3f>& pos,
 }
 
 // Load mesh
-bool load_fvmesh(const std::string& filename, std::vector<vec4i>& quads_pos,
-    std::vector<vec3f>& pos, std::vector<vec4i>& quads_norm,
-    std::vector<vec3f>& norm, std::vector<vec4i>& quads_texcoord,
-    std::vector<vec2f>& texcoord, std::vector<vec4i>& quads_color,
-    std::vector<vec4f>& color) {
+bool load_fvmesh(const string& filename, vector<vec4i>& quads_pos,
+    vector<vec3f>& pos, vector<vec4i>& quads_norm,
+    vector<vec3f>& norm, vector<vec4i>& quads_texcoord,
+    vector<vec2f>& texcoord, vector<vec4i>& quads_color,
+    vector<vec4f>& color) {
     auto ext = get_extension(filename);
     if (ext == "obj" || ext == "OBJ") {
         return load_obj_fvmesh(filename, quads_pos, pos, quads_norm, norm,
@@ -5939,12 +5940,12 @@ bool load_fvmesh(const std::string& filename, std::vector<vec4i>& quads_pos,
 }
 
 // Save mesh
-bool save_fvmesh(const std::string& filename,
-    const std::vector<vec4i>& quads_pos, const std::vector<vec3f>& pos,
-    const std::vector<vec4i>& quads_norm, const std::vector<vec3f>& norm,
-    const std::vector<vec4i>& quads_texcoord,
-    const std::vector<vec2f>& texcoord, const std::vector<vec4i>& quads_color,
-    const std::vector<vec4f>& color, bool ascii) {
+bool save_fvmesh(const string& filename,
+    const vector<vec4i>& quads_pos, const vector<vec3f>& pos,
+    const vector<vec4i>& quads_norm, const vector<vec3f>& norm,
+    const vector<vec4i>& quads_texcoord,
+    const vector<vec2f>& texcoord, const vector<vec4i>& quads_color,
+    const vector<vec4f>& color, bool ascii) {
     auto ext = get_extension(filename);
     if (ext == "obj" || ext == "OBJ") {
         return save_obj_fvmesh(filename, quads_pos, pos, quads_norm, norm,
@@ -5956,13 +5957,13 @@ bool save_fvmesh(const std::string& filename,
 }
 
 // Load obj mesh
-bool load_obj_fvmesh(const std::string& filename, std::vector<vec4i>& quads_pos,
-    std::vector<vec3f>& pos, std::vector<vec4i>& quads_norm,
-    std::vector<vec3f>& norm, std::vector<vec4i>& quads_texcoord,
-    std::vector<vec2f>& texcoord, bool flip_texcoord) {
+bool load_obj_fvmesh(const string& filename, vector<vec4i>& quads_pos,
+    vector<vec3f>& pos, vector<vec4i>& quads_norm,
+    vector<vec3f>& norm, vector<vec4i>& quads_texcoord,
+    vector<vec2f>& texcoord, bool flip_texcoord) {
     // clear
-    std::vector<vec4i> quads_color;
-    std::vector<vec4f> color;
+    vector<vec4i> quads_color;
+    vector<vec4f> color;
     reset_fvmesh_data(quads_pos, pos, quads_norm, norm, quads_texcoord,
         texcoord, quads_color, color);
 
@@ -5972,12 +5973,12 @@ bool load_obj_fvmesh(const std::string& filename, std::vector<vec4i>& quads_pos,
     auto otexcoord = std::deque<vec2f>();
 
     // vertex maps
-    auto pos_map      = std::unordered_map<int, int>();
-    auto texcoord_map = std::unordered_map<int, int>();
-    auto norm_map     = std::unordered_map<int, int>();
+    auto pos_map      = unordered_map<int, int>();
+    auto texcoord_map = unordered_map<int, int>();
+    auto norm_map     = unordered_map<int, int>();
 
     // add vertex
-    auto add_verts = [&](const std::vector<obj_vertex>& verts) {
+    auto add_verts = [&](const vector<obj_vertex>& verts) {
         for (auto& vert : verts) {
             if (!vert.pos) continue;
             auto pos_it = pos_map.find(vert.pos);
@@ -6008,7 +6009,7 @@ bool load_obj_fvmesh(const std::string& filename, std::vector<vec4i>& quads_pos,
     cb.vert     = [&](vec3f v) { opos.push_back(v); };
     cb.norm     = [&](vec3f v) { onorm.push_back(v); };
     cb.texcoord = [&](vec2f v) { otexcoord.push_back(v); };
-    cb.face     = [&](const std::vector<obj_vertex>& verts) {
+    cb.face     = [&](const vector<obj_vertex>& verts) {
         add_verts(verts);
         if (verts.size() == 4) {
             if (verts[0].pos) {
@@ -6055,11 +6056,11 @@ bool load_obj_fvmesh(const std::string& filename, std::vector<vec4i>& quads_pos,
 }
 
 // Load ply mesh
-bool save_obj_fvmesh(const std::string& filename,
-    const std::vector<vec4i>& quads_pos, const std::vector<vec3f>& pos,
-    const std::vector<vec4i>& quads_norm, const std::vector<vec3f>& norm,
-    const std::vector<vec4i>& quads_texcoord,
-    const std::vector<vec2f>& texcoord, bool flip_texcoord) {
+bool save_obj_fvmesh(const string& filename,
+    const vector<vec4i>& quads_pos, const vector<vec3f>& pos,
+    const vector<vec4i>& quads_norm, const vector<vec3f>& norm,
+    const vector<vec4i>& quads_texcoord,
+    const vector<vec2f>& texcoord, bool flip_texcoord) {
     auto fs = open(filename, "wt");
     if (!fs) return false;
 

--- a/yocto/yglio.cpp
+++ b/yocto/yglio.cpp
@@ -898,8 +898,8 @@ float* load_pfm(const char* filename, int* w, int* h, int* nc, int req) {
     if (s > 0) {
         for (auto i = 0; i < nvalues; ++i) {
             auto dta = (uint8_t*)(pixels + i);
-            std::swap(dta[0], dta[3]);
-            std::swap(dta[1], dta[2]);
+            swap(dta[0], dta[3]);
+            swap(dta[1], dta[2]);
         }
     }
 
@@ -4838,7 +4838,7 @@ scene* load_pbrt_scene(
             frame = {normalize(frame.x), normalize(frame.y), normalize(frame.z),
                 frame.o};
             if (stack.back().reverse) {
-                for (auto& t : shp->triangles) std::swap(t.y, t.z);
+                for (auto& t : shp->triangles) swap(t.y, t.z);
             }
             scn->shapes.push_back(shp);
             auto ist   = new instance();
@@ -5112,8 +5112,8 @@ bool save_pbrt_scene(const string& filename, const scene* scn,
 void pbrt_flipyz_scene(const scene* scn) {
     // flip meshes
     for (auto shp : scn->shapes) {
-        for (auto& p : shp->pos) std::swap(p.y, p.z);
-        for (auto& n : shp->norm) std::swap(n.y, n.z);
+        for (auto& p : shp->pos) swap(p.y, p.z);
+        for (auto& n : shp->norm) swap(n.y, n.z);
     }
     for (auto ist : scn->instances) {
         ist->frame = ist->frame *

--- a/yocto/yglio.h
+++ b/yocto/yglio.h
@@ -496,20 +496,20 @@ struct obj_environment {
 
 // Obj callbacks
 struct obj_callbacks {
-    std::function<void(const vec3f&)>                   vert        = {};
-    std::function<void(const vec3f&)>                   norm        = {};
-    std::function<void(const vec2f&)>                   texcoord    = {};
-    std::function<void(const vector<obj_vertex>&)> face        = {};
-    std::function<void(const vector<obj_vertex>&)> line        = {};
-    std::function<void(const vector<obj_vertex>&)> point       = {};
-    std::function<void(const string& name)>        object      = {};
-    std::function<void(const string& name)>        group       = {};
-    std::function<void(const string& name)>        usemtl      = {};
-    std::function<void(const string& name)>        smoothing   = {};
-    std::function<void(const string& name)>        mtllib      = {};
-    std::function<void(const obj_material&)>            material    = {};
-    std::function<void(const obj_camera&)>              camera      = {};
-    std::function<void(const obj_environment&)>         environmnet = {};
+    function<void(const vec3f&)>                   vert        = {};
+    function<void(const vec3f&)>                   norm        = {};
+    function<void(const vec2f&)>                   texcoord    = {};
+    function<void(const vector<obj_vertex>&)> face        = {};
+    function<void(const vector<obj_vertex>&)> line        = {};
+    function<void(const vector<obj_vertex>&)> point       = {};
+    function<void(const string& name)>        object      = {};
+    function<void(const string& name)>        group       = {};
+    function<void(const string& name)>        usemtl      = {};
+    function<void(const string& name)>        smoothing   = {};
+    function<void(const string& name)>        mtllib      = {};
+    function<void(const obj_material&)>            material    = {};
+    function<void(const obj_camera&)>              camera      = {};
+    function<void(const obj_environment&)>         environmnet = {};
 };
 
 // Load obj scene

--- a/yocto/yglio.h
+++ b/yocto/yglio.h
@@ -174,8 +174,7 @@ string get_extension(const string& filename);
 // Get filename without directory.
 string get_filename(const string& filename);
 // Replace extension.
-string replace_extension(
-    const string& filename, const string& ext);
+string replace_extension(const string& filename, const string& ext);
 
 // Check if a file can be opened for reading.
 bool exists_file(const string& filename);
@@ -190,16 +189,16 @@ namespace ygl {
 // Command line parser data. All data should be considered private.
 struct cmdline_parser {
     vector<string> args      = {};  // command line arguments
-    string              usage_cmd = "";  // program name
-    string              usage_hlp = "";  // program help
-    string              usage_opt = "";  // options help
-    string              usage_arg = "";  // arguments help
-    string              error     = "";  // current parse error
+    string         usage_cmd = "";  // program name
+    string         usage_hlp = "";  // program help
+    string         usage_opt = "";  // options help
+    string         usage_arg = "";  // arguments help
+    string         error     = "";  // current parse error
 };
 
 // Initialize a command line parser.
-cmdline_parser make_cmdline_parser(int argc, char** argv,
-    const string& usage, const string& cmd = "");
+cmdline_parser make_cmdline_parser(
+    int argc, char** argv, const string& usage, const string& cmd = "");
 // check if any error occurred and exit appropriately
 void check_cmdline(cmdline_parser& parser);
 
@@ -207,28 +206,26 @@ void check_cmdline(cmdline_parser& parser);
 // Options's names starts with "--" or "-", otherwise they are arguments.
 // vecXX options use space-separated values but all in one argument
 // (use " or ' from the common line). Booleans are flags.
-bool  parse_arg(cmdline_parser& parser, const string& name, bool def,
-     const string& usage);
-int   parse_arg(cmdline_parser& parser, const string& name, int def,
-      const string& usage, bool req = false);
-float parse_arg(cmdline_parser& parser, const string& name, float def,
+bool parse_arg(
+    cmdline_parser& parser, const string& name, bool def, const string& usage);
+int    parse_arg(cmdline_parser& parser, const string& name, int def,
+       const string& usage, bool req = false);
+float  parse_arg(cmdline_parser& parser, const string& name, float def,
+     const string& usage, bool req = false);
+vec2f  parse_arg(cmdline_parser& parser, const string& name, const vec2f& def,
+     const string& usage, bool req = false);
+vec3f  parse_arg(cmdline_parser& parser, const string& name, const vec3f& def,
+     const string& usage, bool req = false);
+string parse_arg(cmdline_parser& parser, const string& name, const string& def,
     const string& usage, bool req = false);
-vec2f parse_arg(cmdline_parser& parser, const string& name,
-    const vec2f& def, const string& usage, bool req = false);
-vec3f parse_arg(cmdline_parser& parser, const string& name,
-    const vec3f& def, const string& usage, bool req = false);
-string parse_arg(cmdline_parser& parser, const string& name,
-    const string& def, const string& usage, bool req = false);
-string parse_arg(cmdline_parser& parser, const string& name,
-    const char* def, const string& usage, bool req = false);
+string parse_arg(cmdline_parser& parser, const string& name, const char* def,
+    const string& usage, bool req = false);
 // Parse all arguments left on the command line.
-vector<string> parse_args(cmdline_parser& parser,
-    const string& name, const vector<string>& def,
-    const string& usage, bool req = false);
+vector<string> parse_args(cmdline_parser& parser, const string& name,
+    const vector<string>& def, const string& usage, bool req = false);
 // Parse a labeled enum, with enum values that are successive integers.
 int parse_arge(cmdline_parser& parser, const string& name, int def,
-    const string& usage, const vector<string>& labels,
-    bool req = false);
+    const string& usage, const vector<string>& labels, bool req = false);
 
 }  // namespace ygl
 
@@ -239,11 +236,11 @@ namespace ygl {
 
 // Load/save a text file
 string load_text(const string& filename);
-bool        save_text(const string& filename, const string& str);
+bool   save_text(const string& filename, const string& str);
 
 // Load/save a binary file
 vector<byte> load_binary(const string& filename);
-bool save_binary(const string& filename, const vector<byte>& data);
+bool         save_binary(const string& filename, const vector<byte>& data);
 
 }  // namespace ygl
 
@@ -283,7 +280,7 @@ namespace ygl {
 
 // Loads/saves a 1 channel volume.
 volume<float> load_volume1f(const string& filename);
-bool save_volume1f(const string& filename, const volume<float>& vol);
+bool          save_volume1f(const string& filename, const volume<float>& vol);
 
 }  // namespace ygl
 
@@ -339,11 +336,9 @@ bool   save_ybin_scene(const string& filename, const scene* scn,
 namespace ygl {
 
 // Load/Save a mesh
-bool load_mesh(const string& filename, vector<int>& points,
-    vector<vec2i>& lines, vector<vec3i>& triangles,
-    vector<vec3f>& pos, vector<vec3f>& norm,
-    vector<vec2f>& texcoord, vector<vec4f>& color,
-    vector<float>& radius);
+bool load_mesh(const string& filename, vector<int>& points, vector<vec2i>& lines,
+    vector<vec3i>& triangles, vector<vec3f>& pos, vector<vec3f>& norm,
+    vector<vec2f>& texcoord, vector<vec4f>& color, vector<float>& radius);
 bool save_mesh(const string& filename, const vector<int>& points,
     const vector<vec2i>& lines, const vector<vec3i>& triangles,
     const vector<vec3f>& pos, const vector<vec3f>& norm,
@@ -352,9 +347,8 @@ bool save_mesh(const string& filename, const vector<int>& points,
 
 // Load/Save a ply mesh
 bool load_ply_mesh(const string& filename, vector<int>& points,
-    vector<vec2i>& lines, vector<vec3i>& triangles,
-    vector<vec3f>& pos, vector<vec3f>& norm,
-    vector<vec2f>& texcoord, vector<vec4f>& color,
+    vector<vec2i>& lines, vector<vec3i>& triangles, vector<vec3f>& pos,
+    vector<vec3f>& norm, vector<vec2f>& texcoord, vector<vec4f>& color,
     vector<float>& radius);
 bool save_ply_mesh(const string& filename, const vector<int>& points,
     const vector<vec2i>& lines, const vector<vec3i>& triangles,
@@ -364,9 +358,8 @@ bool save_ply_mesh(const string& filename, const vector<int>& points,
 
 // Load/Save an OBJ mesh
 bool load_obj_mesh(const string& filename, vector<int>& points,
-    vector<vec2i>& lines, vector<vec3i>& triangles,
-    vector<vec3f>& pos, vector<vec3f>& norm,
-    vector<vec2f>& texcoord, bool flip_texcoord = true);
+    vector<vec2i>& lines, vector<vec3i>& triangles, vector<vec3f>& pos,
+    vector<vec3f>& norm, vector<vec2f>& texcoord, bool flip_texcoord = true);
 bool save_obj_mesh(const string& filename, const vector<int>& points,
     const vector<vec2i>& lines, const vector<vec3i>& triangles,
     const vector<vec3f>& pos, const vector<vec3f>& norm,
@@ -381,26 +374,23 @@ namespace ygl {
 
 // Load/Save a mesh
 bool load_fvmesh(const string& filename, vector<vec4i>& quads_pos,
-    vector<vec3f>& pos, vector<vec4i>& quads_norm,
-    vector<vec3f>& norm, vector<vec4i>& quads_texcoord,
-    vector<vec2f>& texcoord, vector<vec4i>& quads_color,
-    vector<vec4f>& color);
-bool save_fvmesh(const string& filename,
-    const vector<vec4i>& quads_pos, const vector<vec3f>& pos,
-    const vector<vec4i>& quads_norm, const vector<vec3f>& norm,
-    const vector<vec4i>& quads_texcoord,
+    vector<vec3f>& pos, vector<vec4i>& quads_norm, vector<vec3f>& norm,
+    vector<vec4i>& quads_texcoord, vector<vec2f>& texcoord,
+    vector<vec4i>& quads_color, vector<vec4f>& color);
+bool save_fvmesh(const string& filename, const vector<vec4i>& quads_pos,
+    const vector<vec3f>& pos, const vector<vec4i>& quads_norm,
+    const vector<vec3f>& norm, const vector<vec4i>& quads_texcoord,
     const vector<vec2f>& texcoord, const vector<vec4i>& quads_color,
     const vector<vec4f>& color, bool ascii = false);
 
 // Load/Save an OBJ mesh
 bool load_obj_fvmesh(const string& filename, vector<vec4i>& quads_pos,
-    vector<vec3f>& pos, vector<vec4i>& quads_norm,
-    vector<vec3f>& norm, vector<vec4i>& quads_texcoord,
-    vector<vec2f>& texcoord, bool flip_texcoord = true);
-bool save_obj_fvmesh(const string& filename,
-    const vector<vec4i>& quads_pos, const vector<vec3f>& pos,
-    const vector<vec4i>& quads_norm, const vector<vec3f>& norm,
-    const vector<vec4i>& quads_texcoord,
+    vector<vec3f>& pos, vector<vec4i>& quads_norm, vector<vec3f>& norm,
+    vector<vec4i>& quads_texcoord, vector<vec2f>& texcoord,
+    bool flip_texcoord = true);
+bool save_obj_fvmesh(const string& filename, const vector<vec4i>& quads_pos,
+    const vector<vec3f>& pos, const vector<vec4i>& quads_norm,
+    const vector<vec3f>& norm, const vector<vec4i>& quads_texcoord,
     const vector<vec2f>& texcoord, bool flip_texcoord = true);
 
 }  // namespace ygl
@@ -420,8 +410,8 @@ struct obj_vertex {
 // Obj texture information.
 struct obj_texture_info {
     string path  = "";     // file path
-    bool        clamp = false;  // clamp to edge
-    float       scale = 1;      // scale for bump/displacement
+    bool   clamp = false;  // clamp to edge
+    float  scale = 1;      // scale for bump/displacement
     // Properties not explicitly handled.
     unordered_map<string, vector<float>> props;
 };
@@ -429,7 +419,7 @@ struct obj_texture_info {
 // Obj material.
 struct obj_material {
     string name;       // name
-    int         illum = 0;  // MTL illum mode
+    int    illum = 0;  // MTL illum mode
 
     // base values
     vec3f ke  = {0, 0, 0};  // emission color
@@ -476,19 +466,19 @@ struct obj_material {
 
 // Obj camera [extension].
 struct obj_camera {
-    string name;                         // name
-    frame3f     frame    = identity_frame3f;  // transform
-    bool        ortho    = false;             // orthographic
-    vec2f       film     = {0.036f, 0.024f};  // film size (default to 35mm)
-    float       focal    = 0.050f;            // focal length
-    float       aspect   = 16.0f / 9.0f;      // aspect ratio
-    float       aperture = 0;                 // lens aperture
-    float       focus    = maxf;              // focus distance
+    string  name;                         // name
+    frame3f frame    = identity_frame3f;  // transform
+    bool    ortho    = false;             // orthographic
+    vec2f   film     = {0.036f, 0.024f};  // film size (default to 35mm)
+    float   focal    = 0.050f;            // focal length
+    float   aspect   = 16.0f / 9.0f;      // aspect ratio
+    float   aperture = 0;                 // lens aperture
+    float   focus    = maxf;              // focus distance
 };
 
 // Obj environment [extension].
 struct obj_environment {
-    string      name;                      // name
+    string           name;                      // name
     frame3f          frame = identity_frame3f;  // transform
     vec3f            ke    = zero3f;            // emission color
     obj_texture_info ke_txt;                    // emission texture
@@ -496,9 +486,9 @@ struct obj_environment {
 
 // Obj callbacks
 struct obj_callbacks {
-    function<void(const vec3f&)>                   vert        = {};
-    function<void(const vec3f&)>                   norm        = {};
-    function<void(const vec2f&)>                   texcoord    = {};
+    function<void(const vec3f&)>              vert        = {};
+    function<void(const vec3f&)>              norm        = {};
+    function<void(const vec2f&)>              texcoord    = {};
     function<void(const vector<obj_vertex>&)> face        = {};
     function<void(const vector<obj_vertex>&)> line        = {};
     function<void(const vector<obj_vertex>&)> point       = {};
@@ -507,9 +497,9 @@ struct obj_callbacks {
     function<void(const string& name)>        usemtl      = {};
     function<void(const string& name)>        smoothing   = {};
     function<void(const string& name)>        mtllib      = {};
-    function<void(const obj_material&)>            material    = {};
-    function<void(const obj_camera&)>              camera      = {};
-    function<void(const obj_environment&)>         environmnet = {};
+    function<void(const obj_material&)>       material    = {};
+    function<void(const obj_camera&)>         camera      = {};
+    function<void(const obj_environment&)>    environmnet = {};
 };
 
 // Load obj scene
@@ -530,7 +520,7 @@ enum struct ply_type { ply_uchar, ply_int, ply_float, ply_int_list };
 // ply property
 struct ply_property {
     string                     name    = "";
-    ply_type                        type    = ply_type::ply_float;
+    ply_type                   type    = ply_type::ply_float;
     vector<float>              scalars = {};
     vector<std::array<int, 8>> lists   = {};
 };
@@ -538,7 +528,7 @@ struct ply_property {
 // ply element
 struct ply_element {
     string               name       = "";
-    int                       count      = 0;
+    int                  count      = 0;
     vector<ply_property> properties = {};
 };
 
@@ -710,8 +700,8 @@ inline bool print_next(string& str, const string& fmt) {
     return print_value(str, fmt);
 }
 template <typename Arg, typename... Args>
-inline bool print_next(string& str, const string& fmt, const Arg& arg,
-    const Args&... args) {
+inline bool print_next(
+    string& str, const string& fmt, const Arg& arg, const Args&... args) {
     auto pos = fmt.find("{}");
     if (pos == string::npos) return print_value(str, fmt);
     if (!print_value(str, fmt.substr(0, pos))) return false;

--- a/yocto/yglio.h
+++ b/yocto/yglio.h
@@ -95,23 +95,23 @@ namespace ygl {
 // Formats a string `fmt` with values taken from `args`. Uses `{}` as
 // placeholder.
 template <typename... Args>
-inline std::string format(const std::string& fmt, const Args&... args);
+inline string format(const string& fmt, const Args&... args);
 
 // Converts to string.
 template <typename T>
-inline std::string to_string(const T& val);
+inline string to_string(const T& val);
 
 // Prints a formatted string to stdout or file.
 template <typename... Args>
-inline bool print(FILE* fs, const std::string& fmt, const Args&... args);
+inline bool print(FILE* fs, const string& fmt, const Args&... args);
 template <typename... Args>
-inline bool print(const std::string& fmt, const Args&... args) {
+inline bool print(const string& fmt, const Args&... args) {
     return print(stdout, fmt, args...);
 }
 
 // Parse a list of space separated values.
 template <typename... Args>
-inline bool parse(const std::string& str, Args&... args);
+inline bool parse(const string& str, Args&... args);
 template <typename... Args>
 inline bool parse(FILE* fs, Args&... args);
 
@@ -124,15 +124,15 @@ namespace ygl {
 
 // Log info/error/fatal message
 template <typename... Args>
-inline void log_info(const std::string& fmt, const Args&... args);
+inline void log_info(const string& fmt, const Args&... args);
 template <typename... Args>
-inline void log_error(const std::string& fmt, const Args&... args);
+inline void log_error(const string& fmt, const Args&... args);
 template <typename... Args>
-inline void log_fatal(const std::string& fmt, const Args&... args);
+inline void log_fatal(const string& fmt, const Args&... args);
 
 // Setup logging
 void set_log_console(bool enabled);
-void set_log_file(const std::string& filename, bool append = false);
+void set_log_file(const string& filename, bool append = false);
 
 }  // namespace ygl
 
@@ -154,9 +154,9 @@ inline int64_t get_time() {
 namespace ygl {
 
 // Format duration string from nanoseconds
-std::string format_duration(int64_t duration);
+string format_duration(int64_t duration);
 // Format a large integer number in human readable form
-std::string format_num(uint64_t num);
+string format_num(uint64_t num);
 
 }  // namespace ygl
 
@@ -166,19 +166,19 @@ std::string format_num(uint64_t num);
 namespace ygl {
 
 // Normalize path delimiters.
-std::string normalize_path(const std::string& filename);
+string normalize_path(const string& filename);
 // Get directory name (not including '/').
-std::string get_dirname(const std::string& filename);
+string get_dirname(const string& filename);
 // Get extension (not including '.').
-std::string get_extension(const std::string& filename);
+string get_extension(const string& filename);
 // Get filename without directory.
-std::string get_filename(const std::string& filename);
+string get_filename(const string& filename);
 // Replace extension.
-std::string replace_extension(
-    const std::string& filename, const std::string& ext);
+string replace_extension(
+    const string& filename, const string& ext);
 
 // Check if a file can be opened for reading.
-bool exists_file(const std::string& filename);
+bool exists_file(const string& filename);
 
 }  // namespace ygl
 
@@ -189,17 +189,17 @@ namespace ygl {
 
 // Command line parser data. All data should be considered private.
 struct cmdline_parser {
-    std::vector<std::string> args      = {};  // command line arguments
-    std::string              usage_cmd = "";  // program name
-    std::string              usage_hlp = "";  // program help
-    std::string              usage_opt = "";  // options help
-    std::string              usage_arg = "";  // arguments help
-    std::string              error     = "";  // current parse error
+    vector<string> args      = {};  // command line arguments
+    string              usage_cmd = "";  // program name
+    string              usage_hlp = "";  // program help
+    string              usage_opt = "";  // options help
+    string              usage_arg = "";  // arguments help
+    string              error     = "";  // current parse error
 };
 
 // Initialize a command line parser.
 cmdline_parser make_cmdline_parser(int argc, char** argv,
-    const std::string& usage, const std::string& cmd = "");
+    const string& usage, const string& cmd = "");
 // check if any error occurred and exit appropriately
 void check_cmdline(cmdline_parser& parser);
 
@@ -207,27 +207,27 @@ void check_cmdline(cmdline_parser& parser);
 // Options's names starts with "--" or "-", otherwise they are arguments.
 // vecXX options use space-separated values but all in one argument
 // (use " or ' from the common line). Booleans are flags.
-bool  parse_arg(cmdline_parser& parser, const std::string& name, bool def,
-     const std::string& usage);
-int   parse_arg(cmdline_parser& parser, const std::string& name, int def,
-      const std::string& usage, bool req = false);
-float parse_arg(cmdline_parser& parser, const std::string& name, float def,
-    const std::string& usage, bool req = false);
-vec2f parse_arg(cmdline_parser& parser, const std::string& name,
-    const vec2f& def, const std::string& usage, bool req = false);
-vec3f parse_arg(cmdline_parser& parser, const std::string& name,
-    const vec3f& def, const std::string& usage, bool req = false);
-std::string parse_arg(cmdline_parser& parser, const std::string& name,
-    const std::string& def, const std::string& usage, bool req = false);
-std::string parse_arg(cmdline_parser& parser, const std::string& name,
-    const char* def, const std::string& usage, bool req = false);
+bool  parse_arg(cmdline_parser& parser, const string& name, bool def,
+     const string& usage);
+int   parse_arg(cmdline_parser& parser, const string& name, int def,
+      const string& usage, bool req = false);
+float parse_arg(cmdline_parser& parser, const string& name, float def,
+    const string& usage, bool req = false);
+vec2f parse_arg(cmdline_parser& parser, const string& name,
+    const vec2f& def, const string& usage, bool req = false);
+vec3f parse_arg(cmdline_parser& parser, const string& name,
+    const vec3f& def, const string& usage, bool req = false);
+string parse_arg(cmdline_parser& parser, const string& name,
+    const string& def, const string& usage, bool req = false);
+string parse_arg(cmdline_parser& parser, const string& name,
+    const char* def, const string& usage, bool req = false);
 // Parse all arguments left on the command line.
-std::vector<std::string> parse_args(cmdline_parser& parser,
-    const std::string& name, const std::vector<std::string>& def,
-    const std::string& usage, bool req = false);
+vector<string> parse_args(cmdline_parser& parser,
+    const string& name, const vector<string>& def,
+    const string& usage, bool req = false);
 // Parse a labeled enum, with enum values that are successive integers.
-int parse_arge(cmdline_parser& parser, const std::string& name, int def,
-    const std::string& usage, const std::vector<std::string>& labels,
+int parse_arge(cmdline_parser& parser, const string& name, int def,
+    const string& usage, const vector<string>& labels,
     bool req = false);
 
 }  // namespace ygl
@@ -238,12 +238,12 @@ int parse_arge(cmdline_parser& parser, const std::string& name, int def,
 namespace ygl {
 
 // Load/save a text file
-std::string load_text(const std::string& filename);
-bool        save_text(const std::string& filename, const std::string& str);
+string load_text(const string& filename);
+bool        save_text(const string& filename, const string& str);
 
 // Load/save a binary file
-std::vector<byte> load_binary(const std::string& filename);
-bool save_binary(const std::string& filename, const std::vector<byte>& data);
+vector<byte> load_binary(const string& filename);
+bool save_binary(const string& filename, const vector<byte>& data);
 
 }  // namespace ygl
 
@@ -253,16 +253,16 @@ bool save_binary(const std::string& filename, const std::vector<byte>& data);
 namespace ygl {
 
 // Check if an image is HDR based on filename.
-bool is_hdr_filename(const std::string& filename);
+bool is_hdr_filename(const string& filename);
 
 // Loads/saves a 4 channel float image in linear color space.
-image<vec4f> load_image4f(const std::string& filename);
-bool         save_image4f(const std::string& filename, const image<vec4f>& img);
+image<vec4f> load_image4f(const string& filename);
+bool         save_image4f(const string& filename, const image<vec4f>& img);
 image<vec4f> load_image4f_from_memory(const byte* data, int data_size);
 
 // Loads/saves a 4 channel byte image in sRGB color space.
-image<vec4b> load_image4b(const std::string& filename);
-bool         save_image4b(const std::string& filename, const image<vec4b>& img);
+image<vec4b> load_image4b(const string& filename);
+bool         save_image4b(const string& filename, const image<vec4b>& img);
 bool         load_image4b_from_memory(
             const byte* data, int data_size, image<vec4b>& img);
 image<vec4b> load_image4b_from_memory(const byte* data, int data_size);
@@ -271,7 +271,7 @@ image<vec4b> load_image4b_from_memory(const byte* data, int data_size);
 
 // Convenience helper that saves an HDR images as wither a linear HDR file or
 // a tonemapped LDR file depending on file name
-bool save_tonemapped_image(const std::string& filename, const image<vec4f>& hdr,
+bool save_tonemapped_image(const string& filename, const image<vec4f>& hdr,
     float exposure = 0, bool filmic = false, bool srgb = true);
 
 }  // namespace ygl
@@ -282,8 +282,8 @@ bool save_tonemapped_image(const std::string& filename, const image<vec4f>& hdr,
 namespace ygl {
 
 // Loads/saves a 1 channel volume.
-volume<float> load_volume1f(const std::string& filename);
-bool save_volume1f(const std::string& filename, const volume<float>& vol);
+volume<float> load_volume1f(const string& filename);
+bool save_volume1f(const string& filename, const volume<float>& vol);
 
 }  // namespace ygl
 
@@ -293,42 +293,42 @@ bool save_volume1f(const std::string& filename, const volume<float>& vol);
 namespace ygl {
 
 // Load/save a scene in the supported formats.
-scene* load_scene(const std::string& filename, bool load_textures = true,
+scene* load_scene(const string& filename, bool load_textures = true,
     bool skip_missing = true);
-bool   save_scene(const std::string& filename, const scene* scn,
+bool   save_scene(const string& filename, const scene* scn,
       bool save_textures = true, bool skip_missing = true);
 
 // Load/save a scene in the builtin JSON format.
-scene* load_json_scene(const std::string& filename, bool load_textures = true,
+scene* load_json_scene(const string& filename, bool load_textures = true,
     bool skip_missing = true);
-bool   save_json_scene(const std::string& filename, const scene* scn,
+bool   save_json_scene(const string& filename, const scene* scn,
       bool save_textures = true, bool skip_missing = true);
 
 // Load/save a scene from/to OBJ.
-scene* load_obj_scene(const std::string& filename, bool load_textures = true,
+scene* load_obj_scene(const string& filename, bool load_textures = true,
     bool skip_missing = true, bool split_shapes = true);
-bool   save_obj_scene(const std::string& filename, const scene* scn,
+bool   save_obj_scene(const string& filename, const scene* scn,
       bool save_textures = true, bool skip_missing = true);
 
 // Load/save a scene from/to glTF.
-scene* load_gltf_scene(const std::string& filename, bool load_textures = true,
+scene* load_gltf_scene(const string& filename, bool load_textures = true,
     bool skip_missing = true);
-bool   save_gltf_scene(const std::string& filename, const scene* scn,
+bool   save_gltf_scene(const string& filename, const scene* scn,
       bool save_textures = true, bool skip_missing = true);
 
 // Load/save a scene from/to pbrt. This is not robust at all and only
 // works on scene that have been previously adapted since the two renderers
 // are too different to match.
-scene* load_pbrt_scene(const std::string& filename, bool load_textures = true,
+scene* load_pbrt_scene(const string& filename, bool load_textures = true,
     bool skip_missing = true);
-bool   save_pbrt_scene(const std::string& filename, const scene* scn,
+bool   save_pbrt_scene(const string& filename, const scene* scn,
       bool save_textures = true, bool skip_missing = true);
 
 // Load/save a binary dump useful for very fast scene IO. This format is not
 // an archival format and should only be used as an intermediate format.
-scene* load_ybin_scene(const std::string& filename, bool load_textures = true,
+scene* load_ybin_scene(const string& filename, bool load_textures = true,
     bool skip_missing = true);
-bool   save_ybin_scene(const std::string& filename, const scene* scn,
+bool   save_ybin_scene(const string& filename, const scene* scn,
       bool save_textures = true, bool skip_missing = true);
 
 }  // namespace ygl
@@ -339,38 +339,38 @@ bool   save_ybin_scene(const std::string& filename, const scene* scn,
 namespace ygl {
 
 // Load/Save a mesh
-bool load_mesh(const std::string& filename, std::vector<int>& points,
-    std::vector<vec2i>& lines, std::vector<vec3i>& triangles,
-    std::vector<vec3f>& pos, std::vector<vec3f>& norm,
-    std::vector<vec2f>& texcoord, std::vector<vec4f>& color,
-    std::vector<float>& radius);
-bool save_mesh(const std::string& filename, const std::vector<int>& points,
-    const std::vector<vec2i>& lines, const std::vector<vec3i>& triangles,
-    const std::vector<vec3f>& pos, const std::vector<vec3f>& norm,
-    const std::vector<vec2f>& texcoord, const std::vector<vec4f>& color,
-    const std::vector<float>& radius, bool ascii = false);
+bool load_mesh(const string& filename, vector<int>& points,
+    vector<vec2i>& lines, vector<vec3i>& triangles,
+    vector<vec3f>& pos, vector<vec3f>& norm,
+    vector<vec2f>& texcoord, vector<vec4f>& color,
+    vector<float>& radius);
+bool save_mesh(const string& filename, const vector<int>& points,
+    const vector<vec2i>& lines, const vector<vec3i>& triangles,
+    const vector<vec3f>& pos, const vector<vec3f>& norm,
+    const vector<vec2f>& texcoord, const vector<vec4f>& color,
+    const vector<float>& radius, bool ascii = false);
 
 // Load/Save a ply mesh
-bool load_ply_mesh(const std::string& filename, std::vector<int>& points,
-    std::vector<vec2i>& lines, std::vector<vec3i>& triangles,
-    std::vector<vec3f>& pos, std::vector<vec3f>& norm,
-    std::vector<vec2f>& texcoord, std::vector<vec4f>& color,
-    std::vector<float>& radius);
-bool save_ply_mesh(const std::string& filename, const std::vector<int>& points,
-    const std::vector<vec2i>& lines, const std::vector<vec3i>& triangles,
-    const std::vector<vec3f>& pos, const std::vector<vec3f>& norm,
-    const std::vector<vec2f>& texcoord, const std::vector<vec4f>& color,
-    const std::vector<float>& radius, bool ascii = false);
+bool load_ply_mesh(const string& filename, vector<int>& points,
+    vector<vec2i>& lines, vector<vec3i>& triangles,
+    vector<vec3f>& pos, vector<vec3f>& norm,
+    vector<vec2f>& texcoord, vector<vec4f>& color,
+    vector<float>& radius);
+bool save_ply_mesh(const string& filename, const vector<int>& points,
+    const vector<vec2i>& lines, const vector<vec3i>& triangles,
+    const vector<vec3f>& pos, const vector<vec3f>& norm,
+    const vector<vec2f>& texcoord, const vector<vec4f>& color,
+    const vector<float>& radius, bool ascii = false);
 
 // Load/Save an OBJ mesh
-bool load_obj_mesh(const std::string& filename, std::vector<int>& points,
-    std::vector<vec2i>& lines, std::vector<vec3i>& triangles,
-    std::vector<vec3f>& pos, std::vector<vec3f>& norm,
-    std::vector<vec2f>& texcoord, bool flip_texcoord = true);
-bool save_obj_mesh(const std::string& filename, const std::vector<int>& points,
-    const std::vector<vec2i>& lines, const std::vector<vec3i>& triangles,
-    const std::vector<vec3f>& pos, const std::vector<vec3f>& norm,
-    const std::vector<vec2f>& texcoord, bool flip_texcoord = true);
+bool load_obj_mesh(const string& filename, vector<int>& points,
+    vector<vec2i>& lines, vector<vec3i>& triangles,
+    vector<vec3f>& pos, vector<vec3f>& norm,
+    vector<vec2f>& texcoord, bool flip_texcoord = true);
+bool save_obj_mesh(const string& filename, const vector<int>& points,
+    const vector<vec2i>& lines, const vector<vec3i>& triangles,
+    const vector<vec3f>& pos, const vector<vec3f>& norm,
+    const vector<vec2f>& texcoord, bool flip_texcoord = true);
 
 }  // namespace ygl
 
@@ -380,28 +380,28 @@ bool save_obj_mesh(const std::string& filename, const std::vector<int>& points,
 namespace ygl {
 
 // Load/Save a mesh
-bool load_fvmesh(const std::string& filename, std::vector<vec4i>& quads_pos,
-    std::vector<vec3f>& pos, std::vector<vec4i>& quads_norm,
-    std::vector<vec3f>& norm, std::vector<vec4i>& quads_texcoord,
-    std::vector<vec2f>& texcoord, std::vector<vec4i>& quads_color,
-    std::vector<vec4f>& color);
-bool save_fvmesh(const std::string& filename,
-    const std::vector<vec4i>& quads_pos, const std::vector<vec3f>& pos,
-    const std::vector<vec4i>& quads_norm, const std::vector<vec3f>& norm,
-    const std::vector<vec4i>& quads_texcoord,
-    const std::vector<vec2f>& texcoord, const std::vector<vec4i>& quads_color,
-    const std::vector<vec4f>& color, bool ascii = false);
+bool load_fvmesh(const string& filename, vector<vec4i>& quads_pos,
+    vector<vec3f>& pos, vector<vec4i>& quads_norm,
+    vector<vec3f>& norm, vector<vec4i>& quads_texcoord,
+    vector<vec2f>& texcoord, vector<vec4i>& quads_color,
+    vector<vec4f>& color);
+bool save_fvmesh(const string& filename,
+    const vector<vec4i>& quads_pos, const vector<vec3f>& pos,
+    const vector<vec4i>& quads_norm, const vector<vec3f>& norm,
+    const vector<vec4i>& quads_texcoord,
+    const vector<vec2f>& texcoord, const vector<vec4i>& quads_color,
+    const vector<vec4f>& color, bool ascii = false);
 
 // Load/Save an OBJ mesh
-bool load_obj_fvmesh(const std::string& filename, std::vector<vec4i>& quads_pos,
-    std::vector<vec3f>& pos, std::vector<vec4i>& quads_norm,
-    std::vector<vec3f>& norm, std::vector<vec4i>& quads_texcoord,
-    std::vector<vec2f>& texcoord, bool flip_texcoord = true);
-bool save_obj_fvmesh(const std::string& filename,
-    const std::vector<vec4i>& quads_pos, const std::vector<vec3f>& pos,
-    const std::vector<vec4i>& quads_norm, const std::vector<vec3f>& norm,
-    const std::vector<vec4i>& quads_texcoord,
-    const std::vector<vec2f>& texcoord, bool flip_texcoord = true);
+bool load_obj_fvmesh(const string& filename, vector<vec4i>& quads_pos,
+    vector<vec3f>& pos, vector<vec4i>& quads_norm,
+    vector<vec3f>& norm, vector<vec4i>& quads_texcoord,
+    vector<vec2f>& texcoord, bool flip_texcoord = true);
+bool save_obj_fvmesh(const string& filename,
+    const vector<vec4i>& quads_pos, const vector<vec3f>& pos,
+    const vector<vec4i>& quads_norm, const vector<vec3f>& norm,
+    const vector<vec4i>& quads_texcoord,
+    const vector<vec2f>& texcoord, bool flip_texcoord = true);
 
 }  // namespace ygl
 
@@ -419,16 +419,16 @@ struct obj_vertex {
 
 // Obj texture information.
 struct obj_texture_info {
-    std::string path  = "";     // file path
+    string path  = "";     // file path
     bool        clamp = false;  // clamp to edge
     float       scale = 1;      // scale for bump/displacement
     // Properties not explicitly handled.
-    std::unordered_map<std::string, std::vector<float>> props;
+    unordered_map<string, vector<float>> props;
 };
 
 // Obj material.
 struct obj_material {
-    std::string name;       // name
+    string name;       // name
     int         illum = 0;  // MTL illum mode
 
     // base values
@@ -471,12 +471,12 @@ struct obj_material {
     obj_texture_info vd_txt;  // density
 
     // Properties not explicitly handled.
-    std::unordered_map<std::string, std::vector<std::string>> props;
+    unordered_map<string, vector<string>> props;
 };
 
 // Obj camera [extension].
 struct obj_camera {
-    std::string name;                         // name
+    string name;                         // name
     frame3f     frame    = identity_frame3f;  // transform
     bool        ortho    = false;             // orthographic
     vec2f       film     = {0.036f, 0.024f};  // film size (default to 35mm)
@@ -488,7 +488,7 @@ struct obj_camera {
 
 // Obj environment [extension].
 struct obj_environment {
-    std::string      name;                      // name
+    string      name;                      // name
     frame3f          frame = identity_frame3f;  // transform
     vec3f            ke    = zero3f;            // emission color
     obj_texture_info ke_txt;                    // emission texture
@@ -499,21 +499,21 @@ struct obj_callbacks {
     std::function<void(const vec3f&)>                   vert        = {};
     std::function<void(const vec3f&)>                   norm        = {};
     std::function<void(const vec2f&)>                   texcoord    = {};
-    std::function<void(const std::vector<obj_vertex>&)> face        = {};
-    std::function<void(const std::vector<obj_vertex>&)> line        = {};
-    std::function<void(const std::vector<obj_vertex>&)> point       = {};
-    std::function<void(const std::string& name)>        object      = {};
-    std::function<void(const std::string& name)>        group       = {};
-    std::function<void(const std::string& name)>        usemtl      = {};
-    std::function<void(const std::string& name)>        smoothing   = {};
-    std::function<void(const std::string& name)>        mtllib      = {};
+    std::function<void(const vector<obj_vertex>&)> face        = {};
+    std::function<void(const vector<obj_vertex>&)> line        = {};
+    std::function<void(const vector<obj_vertex>&)> point       = {};
+    std::function<void(const string& name)>        object      = {};
+    std::function<void(const string& name)>        group       = {};
+    std::function<void(const string& name)>        usemtl      = {};
+    std::function<void(const string& name)>        smoothing   = {};
+    std::function<void(const string& name)>        mtllib      = {};
     std::function<void(const obj_material&)>            material    = {};
     std::function<void(const obj_camera&)>              camera      = {};
     std::function<void(const obj_environment&)>         environmnet = {};
 };
 
 // Load obj scene
-bool load_obj(const std::string& filename, const obj_callbacks& cb,
+bool load_obj(const string& filename, const obj_callbacks& cb,
     bool geometry_only = false, bool skip_missing = true,
     bool flip_texcoord = true, bool flip_tr = true);
 
@@ -529,26 +529,26 @@ enum struct ply_type { ply_uchar, ply_int, ply_float, ply_int_list };
 
 // ply property
 struct ply_property {
-    std::string                     name    = "";
+    string                     name    = "";
     ply_type                        type    = ply_type::ply_float;
-    std::vector<float>              scalars = {};
-    std::vector<std::array<int, 8>> lists   = {};
+    vector<float>              scalars = {};
+    vector<std::array<int, 8>> lists   = {};
 };
 
 // ply element
 struct ply_element {
-    std::string               name       = "";
+    string               name       = "";
     int                       count      = 0;
-    std::vector<ply_property> properties = {};
+    vector<ply_property> properties = {};
 };
 
 // simple ply api data
 struct ply_data {
-    std::vector<ply_element> elements = {};
+    vector<ply_element> elements = {};
 };
 
 // Load ply mesh
-ply_data load_ply(const std::string& filename);
+ply_data load_ply(const string& filename);
 
 }  // namespace ygl
 
@@ -558,64 +558,37 @@ ply_data load_ply(const std::string& filename);
 namespace ygl {
 
 // Prints basic types
-inline bool print_value(std::string& str, const std::string& val) {
+inline bool print_value(string& str, const string& val) {
     str += val;
     return true;
 }
-inline bool print_value(std::string& str, const char* val) {
+inline bool print_value(string& str, const char* val) {
     str += val;
     return true;
 }
-inline bool print_value(std::string& str, int val) {
+inline bool print_value(string& str, int val) {
     str += std::to_string(val);
     return true;
 }
-inline bool print_value(std::string& str, float val) {
+inline bool print_value(string& str, float val) {
     str += std::to_string(val);
     return true;
 }
-inline bool print_value(std::string& str, double val) {
+inline bool print_value(string& str, double val) {
     str += std::to_string(val);
     return true;
 }
 
 // Print compound types.
 template <typename T>
-inline bool print_value(std::string& str, const vec2<T>& v) {
+inline bool print_value(string& str, const vec2<T>& v) {
     if (!print_value(str, v.x)) return false;
     if (!print_value(str, " ")) return false;
     if (!print_value(str, v.y)) return false;
     return true;
 }
 template <typename T>
-inline bool print_value(std::string& str, const vec3<T>& v) {
-    if (!print_value(str, v.x)) return false;
-    if (!print_value(str, " ")) return false;
-    if (!print_value(str, v.y)) return false;
-    if (!print_value(str, " ")) return false;
-    if (!print_value(str, v.z)) return false;
-    return true;
-}
-template <typename T>
-inline bool print_value(std::string& str, const vec4<T>& v) {
-    if (!print_value(str, v.x)) return false;
-    if (!print_value(str, " ")) return false;
-    if (!print_value(str, v.y)) return false;
-    if (!print_value(str, " ")) return false;
-    if (!print_value(str, v.z)) return false;
-    if (!print_value(str, " ")) return false;
-    if (!print_value(str, v.w)) return false;
-    return true;
-}
-template <typename T>
-inline bool print_value(std::string& str, const mat2<T>& v) {
-    if (!print_value(str, v.x)) return false;
-    if (!print_value(str, " ")) return false;
-    if (!print_value(str, v.y)) return false;
-    return true;
-}
-template <typename T>
-inline bool print_value(std::string& str, const mat3<T>& v) {
+inline bool print_value(string& str, const vec3<T>& v) {
     if (!print_value(str, v.x)) return false;
     if (!print_value(str, " ")) return false;
     if (!print_value(str, v.y)) return false;
@@ -624,7 +597,7 @@ inline bool print_value(std::string& str, const mat3<T>& v) {
     return true;
 }
 template <typename T>
-inline bool print_value(std::string& str, const mat4<T>& v) {
+inline bool print_value(string& str, const vec4<T>& v) {
     if (!print_value(str, v.x)) return false;
     if (!print_value(str, " ")) return false;
     if (!print_value(str, v.y)) return false;
@@ -635,7 +608,34 @@ inline bool print_value(std::string& str, const mat4<T>& v) {
     return true;
 }
 template <typename T>
-inline bool print_value(std::string& str, const frame2<T>& v) {
+inline bool print_value(string& str, const mat2<T>& v) {
+    if (!print_value(str, v.x)) return false;
+    if (!print_value(str, " ")) return false;
+    if (!print_value(str, v.y)) return false;
+    return true;
+}
+template <typename T>
+inline bool print_value(string& str, const mat3<T>& v) {
+    if (!print_value(str, v.x)) return false;
+    if (!print_value(str, " ")) return false;
+    if (!print_value(str, v.y)) return false;
+    if (!print_value(str, " ")) return false;
+    if (!print_value(str, v.z)) return false;
+    return true;
+}
+template <typename T>
+inline bool print_value(string& str, const mat4<T>& v) {
+    if (!print_value(str, v.x)) return false;
+    if (!print_value(str, " ")) return false;
+    if (!print_value(str, v.y)) return false;
+    if (!print_value(str, " ")) return false;
+    if (!print_value(str, v.z)) return false;
+    if (!print_value(str, " ")) return false;
+    if (!print_value(str, v.w)) return false;
+    return true;
+}
+template <typename T>
+inline bool print_value(string& str, const frame2<T>& v) {
     if (!print_value(str, v.x)) return false;
     if (!print_value(str, " ")) return false;
     if (!print_value(str, v.y)) return false;
@@ -644,7 +644,7 @@ inline bool print_value(std::string& str, const frame2<T>& v) {
     return true;
 }
 template <typename T>
-inline bool print_value(std::string& str, const frame3<T>& v) {
+inline bool print_value(string& str, const frame3<T>& v) {
     if (!print_value(str, v.x)) return false;
     if (!print_value(str, " ")) return false;
     if (!print_value(str, v.y)) return false;
@@ -655,35 +655,35 @@ inline bool print_value(std::string& str, const frame3<T>& v) {
     return true;
 }
 template <typename T>
-inline bool print_value(std::string& str, const bbox1<T>& v) {
+inline bool print_value(string& str, const bbox1<T>& v) {
     if (!print_value(str, v.min)) return false;
     if (!print_value(str, " ")) return false;
     if (!print_value(str, v.max)) return false;
     return true;
 }
 template <typename T>
-inline bool print_value(std::string& str, const bbox2<T>& v) {
+inline bool print_value(string& str, const bbox2<T>& v) {
     if (!print_value(str, v.min)) return false;
     if (!print_value(str, " ")) return false;
     if (!print_value(str, v.max)) return false;
     return true;
 }
 template <typename T>
-inline bool print_value(std::string& str, const bbox3<T>& v) {
+inline bool print_value(string& str, const bbox3<T>& v) {
     if (!print_value(str, v.min)) return false;
     if (!print_value(str, " ")) return false;
     if (!print_value(str, v.max)) return false;
     return true;
 }
 template <typename T>
-inline bool print_value(std::string& str, const bbox4<T>& v) {
+inline bool print_value(string& str, const bbox4<T>& v) {
     if (!print_value(str, v.min)) return false;
     if (!print_value(str, " ")) return false;
     if (!print_value(str, v.max)) return false;
     return true;
 }
 template <typename T>
-inline bool print_value(std::string& str, const ray2<T>& v) {
+inline bool print_value(string& str, const ray2<T>& v) {
     if (!print_value(str, v.o)) return false;
     if (!print_value(str, " ")) return false;
     if (!print_value(str, v.d)) return false;
@@ -694,7 +694,7 @@ inline bool print_value(std::string& str, const ray2<T>& v) {
     return true;
 }
 template <typename T>
-inline bool print_value(std::string& str, const ray3<T>& v) {
+inline bool print_value(string& str, const ray3<T>& v) {
     if (!print_value(str, v.o)) return false;
     if (!print_value(str, " ")) return false;
     if (!print_value(str, v.d)) return false;
@@ -706,14 +706,14 @@ inline bool print_value(std::string& str, const ray3<T>& v) {
 }
 
 // Prints a string.
-inline bool print_next(std::string& str, const std::string& fmt) {
+inline bool print_next(string& str, const string& fmt) {
     return print_value(str, fmt);
 }
 template <typename Arg, typename... Args>
-inline bool print_next(std::string& str, const std::string& fmt, const Arg& arg,
+inline bool print_next(string& str, const string& fmt, const Arg& arg,
     const Args&... args) {
     auto pos = fmt.find("{}");
-    if (pos == std::string::npos) return print_value(str, fmt);
+    if (pos == string::npos) return print_value(str, fmt);
     if (!print_value(str, fmt.substr(0, pos))) return false;
     if (!print_value(str, arg)) return false;
     return print_next(str, fmt.substr(pos + 2), args...);
@@ -722,29 +722,29 @@ inline bool print_next(std::string& str, const std::string& fmt, const Arg& arg,
 // Formats a string `fmt` with values taken from `args`. Uses `{}` as
 // placeholder.
 template <typename... Args>
-inline std::string format(const std::string& fmt, const Args&... args) {
-    auto str = std::string();
+inline string format(const string& fmt, const Args&... args) {
+    auto str = string();
     print_next(str, fmt, args...);
     return str;
 }
 
 // Prints a string.
 template <typename... Args>
-inline bool print(FILE* fs, const std::string& fmt, const Args&... args) {
+inline bool print(FILE* fs, const string& fmt, const Args&... args) {
     auto str = format(fmt, args...);
     return fprintf(fs, "%s", str.c_str()) >= 0;
 }
 
 // Converts to string.
 template <typename T>
-inline std::string to_string(const T& val) {
-    auto str = std::string();
+inline string to_string(const T& val) {
+    auto str = string();
     print_value(str, val);
     return str;
 }
 
 // Prints basic types to string
-inline bool _parse(const char*& str, std::string& val) {
+inline bool _parse(const char*& str, string& val) {
     auto n = 0;
     char buf[4096];
     if (sscanf(str, "%4095s%n", buf, &n) != 1) return false;
@@ -772,7 +772,7 @@ inline bool _parse(const char*& str, double& val) {
 }
 
 // Prints basic types to stream
-inline bool _parse(FILE* fs, std::string& val) {
+inline bool _parse(FILE* fs, string& val) {
     char buf[4096];
     if (fscanf(fs, "%4095s", buf) != 1) return false;
     val = buf;
@@ -869,7 +869,7 @@ inline bool _is_whitespace(const char* str) {
 
 // Parse a list of space separated values.
 template <typename... Args>
-inline bool parse(const std::string& str, Args&... args) {
+inline bool parse(const string& str, Args&... args) {
     auto str_ = str.c_str();
     if (!_parse_next(str_, args...)) return false;
     return _is_whitespace(str_);
@@ -893,15 +893,15 @@ void log_message(const char* lbl, const char* msg);
 
 // Log info/error/fatal message
 template <typename... Args>
-inline void log_info(const std::string& fmt, const Args&... args) {
+inline void log_info(const string& fmt, const Args&... args) {
     log_message("INFO ", format(fmt, args...).c_str());
 }
 template <typename... Args>
-inline void log_error(const std::string& fmt, const Args&... args) {
+inline void log_error(const string& fmt, const Args&... args) {
     log_message("ERROR", format(fmt, args...).c_str());
 }
 template <typename... Args>
-inline void log_fatal(const std::string& fmt, const Args&... args) {
+inline void log_fatal(const string& fmt, const Args&... args) {
     log_message("FATAL", format(fmt, args...).c_str());
     exit(1);
 }


### PR DESCRIPTION
Move the the convention of std::<container> to <container>.