### PR TITLE
better edge_map

### DIFF
--- a/yocto/ygl.h
+++ b/yocto/ygl.h
@@ -2408,6 +2408,7 @@ void compute_matrix_skinning(const vector<vec3f>& positions,
     vector<vec3f>& skinned_positions, vector<vec3f>& skinned_normals);
 
 // Dictionary to store edge information.
+// key: edge, value: (edge index, adjacent face, other adjacent face)
 using edge_map = unordered_map<vec2i, vec3i>;
 
 // Create key entry for edge_map

--- a/yocto/ygl.h
+++ b/yocto/ygl.h
@@ -2408,13 +2408,15 @@ void compute_matrix_skinning(const vector<vec3f>& positions,
     vector<vec3f>& skinned_positions, vector<vec3f>& skinned_normals);
 
 // Dictionary to store edge information.
-using edge_map = unordered_map<vec2i, vec2i>;
+using edge_map = unordered_map<vec2i, vec3i>;
 
+// Create key entry for edge_map
+vec2i make_edge(const vec2i& e);
 // Initialize an edge map with elements.
 void insert_edges(edge_map& emap, const vector<vec3i>& triangles);
 void insert_edges(edge_map& emap, const vector<vec4i>& quads);
 // Insert an edge and return its index
-int insert_edge(edge_map& emap, const vec2i& edge);
+int insert_edge(edge_map& emap, const vec2i& edge, int face);
 // Get the edge index / insertion count
 int get_edge_index(const edge_map& emap, const vec2i& edge);
 int get_edge_count(const edge_map& emap, const vec2i& edge);


### PR DESCRIPTION
Small change to the edge_map. Instead of mapping each edge to number of adjacent faces (`1` or `2`), it maps to the indices of those adjacent faces (`-1` if missing).

This adds little overhead (the value is `vec3i` instead of `vec2i`) but this kind of edge map is more powerful and provably the only data needed to perform complex discrete geometry processings (such as compute mesh graphs).