### PR TITLE
Changed public API code comments in accordance with doxygen convention.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -47,9 +47,9 @@ test the library:
 Here are some test images rendered with the path tracer. More images are 
 included in the project site.
 
-![Example materials: matte, plastic, metal, glass, subsurface, normal mapping](images/features1.png)
+![Example materials: matte, plastic, metal, glass, subsurface, normal mapping](https://raw.githubusercontent.com/xelatihy/yocto-gl/master/images/features1.png)
 
-![Example shapes: procedural shapes, Catmull-Clark subdivision, hairs, displacement mapping](images/features2.png)
+![Example shapes: procedural shapes, Catmull-Clark subdivision, hairs, displacement mapping](https://raw.githubusercontent.com/xelatihy/yocto-gl/master/images/features2.png)
 
 ## Design Considerations
 

--- a/yocto/yocto_bvh.h
+++ b/yocto/yocto_bvh.h
@@ -1,51 +1,51 @@
-//
-// # Yocto/BVH: Tiny library for ray-object intersection using a BVH
-//
-//
-// Yocto/BVH is a simple implementation of ray intersection and
-// closest queries using a two-level BVH data structure. We also include
-// low-level intersection and closet point primitives.
-// Alternatively the library also support wrapping Intel's Embree.
-//
-//
-// ## Ray-Scene and Closest-Point Queries
-//
-// Yocto/GL provides ray-scene intersection for points, lines, triangles and
-// quads accelerated by a two-level BVH data structure. Our BVH is written for
-// minimal code and not maximum speed, but still gives reasonable results. We
-// suggest the use of Intel's Embree as a more efficient alternative.
-//
-// In Yocto/Bvh, shapes are described as collections of indexed primitives
-// (points/lines/triangles/quads) like the standard triangle mesh used in
-// real-time graphics. A scene if represented as transformed instances of
-// shapes. The internal data structure is a two-level BVH, with a BVH for each
-// shape and one top-level BVH for the whole scene. This design support
-// instancing for large scenes and easy BVH refitting for interactive
-// applications.
-//
-// In these functions triangles are parameterized with uv written
-// w.r.t the (p1-p0) and (p2-p0) axis respectively. Quads are internally handled
-// as pairs of two triangles p0,p1,p3 and p2,p3,p1, with the u/v coordinates
-// of the second triangle corrected as 1-u and 1-v to produce a quad
-// parametrization where u and v go from 0 to 1. Degenerate quads with p2==p3
-// represent triangles correctly, an this convention is used throught the
-// library. This is equivalent to Intel's Embree.
-//
-// Shape and scene data is not copied from the application to the BVH to
-// improve memory footprint at the price of convenience. Shape data is
-// explixitly passed on evey call, while instance data uses callbacks,
-// since each application has its own conventions for storing those.
-// To make usage more convenite, we provide `bvh_XXX_data` to hold application
-// data and convenience wrappers for all functions.
-//
-// We support working either on the whole scene or on a single shape. In the
-// description below yoi will see this dual API defined.
-//
-// 1. build the shape/scene BVH with `build_bvh()`;
-// 2. perform ray-shape intersection with `intersect_bvh()`
-// 3. perform point overlap queries with `overlap_bvh()`
-// 4. refit BVH for dynamic applications with `refit_bvh`
-//
+///
+/// # Yocto/BVH: Tiny library for ray-object intersection using a BVH
+///
+///
+/// Yocto/BVH is a simple implementation of ray intersection and
+/// closest queries using a two-level BVH data structure. We also include
+/// low-level intersection and closet point primitives.
+/// Alternatively the library also support wrapping Intel's Embree.
+///
+///
+/// ## Ray-Scene and Closest-Point Queries
+///
+/// Yocto/GL provides ray-scene intersection for points, lines, triangles and
+/// quads accelerated by a two-level BVH data structure. Our BVH is written for
+/// minimal code and not maximum speed, but still gives reasonable results. We
+/// suggest the use of Intel's Embree as a more efficient alternative.
+///
+/// In Yocto/Bvh, shapes are described as collections of indexed primitives
+/// (points/lines/triangles/quads) like the standard triangle mesh used in
+/// real-time graphics. A scene if represented as transformed instances of
+/// shapes. The internal data structure is a two-level BVH, with a BVH for each
+/// shape and one top-level BVH for the whole scene. This design support
+/// instancing for large scenes and easy BVH refitting for interactive
+/// applications.
+///
+/// In these functions triangles are parameterized with uv written
+/// w.r.t the (p1-p0) and (p2-p0) axis respectively. Quads are internally handled
+/// as pairs of two triangles p0,p1,p3 and p2,p3,p1, with the u/v coordinates
+/// of the second triangle corrected as 1-u and 1-v to produce a quad
+/// parametrization where u and v go from 0 to 1. Degenerate quads with p2==p3
+/// represent triangles correctly, an this convention is used throught the
+/// library. This is equivalent to Intel's Embree.
+///
+/// Shape and scene data is not copied from the application to the BVH to
+/// improve memory footprint at the price of convenience. Shape data is
+/// explixitly passed on evey call, while instance data uses callbacks,
+/// since each application has its own conventions for storing those.
+/// To make usage more convenite, we provide `bvh_XXX_data` to hold application
+/// data and convenience wrappers for all functions.
+///
+/// We support working either on the whole scene or on a single shape. In the
+/// description below yoi will see this dual API defined.
+///
+/// 1. build the shape/scene BVH with `build_bvh()`;
+/// 2. perform ray-shape intersection with `intersect_bvh()`
+/// 3. perform point overlap queries with `overlap_bvh()`
+/// 4. refit BVH for dynamic applications with `refit_bvh`
+///
 
 //
 // LICENSE:
@@ -96,10 +96,10 @@
 // -----------------------------------------------------------------------------
 namespace yocto {
 
-// Maximum number of primitives per BVH node.
+/// Maximum number of primitives per BVH node.
 const int bvh_max_prims = 4;
 
-// BVH array view
+/// BVH array view
 template <typename T>
 struct bvh_span {
   bvh_span() : ptr{nullptr}, count{0} {}
@@ -119,7 +119,7 @@ struct bvh_span {
   int      count = 0;
 };
 
-// BVH array view with stride
+/// BVH array view with stride
 template <typename T>
 struct bvh_sspan {
   bvh_sspan() : ptr{nullptr}, count{0}, stride{0} {}
@@ -139,10 +139,10 @@ struct bvh_sspan {
   int         stride = 0;
 };
 
-// BVH tree node containing its bounds, indices to the BVH arrays of either
-// primitives or internal nodes, the node element type,
-// and the split axis. Leaf and internal nodes are identical, except that
-// indices refer to primitives for leaf nodes or other nodes for internal nodes.
+/// BVH tree node containing its bounds, indices to the BVH arrays of either
+/// primitives or internal nodes, the node element type,
+/// and the split axis. Leaf and internal nodes are identical, except that
+/// indices refer to primitives for leaf nodes or other nodes for internal nodes.
 struct bvh_node {
   bbox3f bbox;
   short  num;
@@ -151,10 +151,10 @@ struct bvh_node {
   int    prims[bvh_max_prims];
 };
 
-// BVH tree stored as a node array with the tree structure is encoded using
-// array indices. BVH nodes indices refer to either the node array,
-// for internal nodes, or the primitive arrays, for leaf nodes.
-// Applicxation data is not stored explicitly.
+/// BVH tree stored as a node array with the tree structure is encoded using
+/// array indices. BVH nodes indices refer to either the node array,
+/// for internal nodes, or the primitive arrays, for leaf nodes.
+/// Applicxation data is not stored explicitly.
 struct bvh_shape {
   // elements
   bvh_span<int>   points    = {};
@@ -179,7 +179,7 @@ struct bvh_shape {
 #endif
 };
 
-// Instance for a scene BVH.
+/// Instance for a scene BVH.
 struct bvh_instance {
   frame3f frame = identity3x4f;
   int     shape = -1;
@@ -202,7 +202,7 @@ struct bvh_scene {
 #endif
 };
 
-// bvh build params
+/// bvh build params
 struct bvh_params {
   bool high_quality = false;
 #if YOCTO_EMBREE
@@ -214,7 +214,7 @@ struct bvh_params {
   std::atomic<bool>* cancel     = nullptr;
 };
 
-// Initialize bvh data
+/// Initialize bvh data
 inline bvh_shape make_points_bvh(
     bvh_span<int> points, bvh_span<vec3f> positions, bvh_span<float> radius) {
   return bvh_shape{points, {}, {}, {}, {}, positions, radius};
@@ -240,43 +240,43 @@ inline bvh_scene make_instances_bvh(
   return bvh_scene{instances, shapes};
 }
 
-// Build the bvh acceleration structure.
+/// Build the bvh acceleration structure.
 void build_bvh(bvh_shape& bvh, const bvh_params& params);
 void build_bvh(bvh_scene& bvh, const bvh_params& params);
 
-// Refit bvh data
+/// Refit bvh data
 void refit_bvh(bvh_shape& bvh, const bvh_params& params);
 void refit_bvh(bvh_scene& bvh, const vector<int>& updated_shapes,
     const bvh_params& params);
 
-// Intersect ray with a bvh returning either the first or any intersection
-// depending on `find_any`. Returns the ray distance , the instance id,
-// the shape element index and the element barycentric coordinates.
+/// Intersect ray with a bvh returning either the first or any intersection
+/// depending on `find_any`. Returns the ray distance , the instance id,
+/// the shape element index and the element barycentric coordinates.
 bool intersect_bvh(const bvh_shape& bvh, const ray3f& ray, int& element,
     vec2f& uv, float& distance, bool find_any = false);
 bool intersect_bvh(const bvh_scene& bvh, const ray3f& ray, int& instance,
     int& element, vec2f& uv, float& distance, bool find_any = false,
     bool non_rigid_frames = true);
-// Intersects a single instance.
+/// Intersects a single instance.
 bool intersect_bvh(const bvh_scene& bvh, int instance, const ray3f& ray,
     int& element, vec2f& uv, float& distance, bool find_any = false,
     bool non_rigid_frames = true);
 
-// Find a shape element that overlaps a point within a given distance
-// max distance, returning either the closest or any overlap depending on
-// `find_any`. Returns the point distance, the instance id, the shape element
-// index and the element barycentric coordinates.
+/// Find a shape element that overlaps a point within a given distance
+/// max distance, returning either the closest or any overlap depending on
+/// `find_any`. Returns the point distance, the instance id, the shape element
+/// index and the element barycentric coordinates.
 bool overlap_bvh(const bvh_shape& bvh, const vec3f& pos, float max_distance,
     int& element, vec2f& uv, float& distance, bool find_any = false);
 bool overlap_bvh(const bvh_scene& bvh, const vec3f& pos, float max_distance,
     int& instance, int& element, vec2f& uv, float& distance,
     bool find_any = false, bool non_rigid_frames = true);
 
-// Results of intersect_xxx and overlap_xxx functions that include hit flag,
-// instance id, shape element id, shape element uv and intersection distance.
-// The values are all set for scene intersection. Shape intersection does not
-// set the instance id and element intersections do not set shape element id
-// and the instance id. Results values are set only if hit is true.
+/// Results of intersect_xxx and overlap_xxx functions that include hit flag,
+/// instance id, shape element id, shape element uv and intersection distance.
+/// The values are all set for scene intersection. Shape intersection does not
+/// set the instance id and element intersections do not set shape element id
+/// and the instance id. Results values are set only if hit is true.
 struct bvh_intersection {
   int   instance = -1;
   int   element  = -1;
@@ -304,7 +304,7 @@ bvh_intersection overlap_bvh(const bvh_scene& bvh, const vec3f& pos,
 // -----------------------------------------------------------------------------
 namespace yocto {
 
-// Print bvh statistics.
+/// Print bvh statistics.
 string format_stats(const bvh_shape& bvh);
 string format_stats(const bvh_scene& bvh);
 
@@ -315,74 +315,74 @@ string format_stats(const bvh_scene& bvh);
 // -----------------------------------------------------------------------------
 namespace yocto {
 
-// Intersect a ray with a point (approximate).
-// Based on http://geomalgorithms.com/a02-lines.html.
+/// Intersect a ray with a point (approximate).
+/// Based on http://geomalgorithms.com/a02-lines.html.
 bool intersect_point(
     const ray3f& ray, const vec3f& p, float r, vec2f& uv, float& dist);
 
-// Intersect a ray with a line (approximate).
-// Based on http://geomalgorithms.com/a05-intersect-1.html and
-// http://geomalgorithms.com/a07-distance.html#
-//     dist3D_Segment_to_Segment
+/// Intersect a ray with a line (approximate).
+/// Based on http://geomalgorithms.com/a05-intersect-1.html and
+/// http://geomalgorithms.com/a07-distance.html#
+///     dist3D_Segment_to_Segment
 bool intersect_line(const ray3f& ray, const vec3f& p0, const vec3f& p1,
     float r0, float r1, vec2f& uv, float& dist);
 
-// Intersect a ray with a triangle.
+/// Intersect a ray with a triangle.
 bool intersect_triangle(const ray3f& ray, const vec3f& p0, const vec3f& p1,
     const vec3f& p2, vec2f& uv, float& dist);
 
-// Intersect a ray with a quad represented as two triangles (0,1,3) and
-// (2,3,1), with the uv coordinates of the second triangle corrected by u =
-// 1-u' and v = 1-v' to produce a quad parametrization where u and v go from 0
-// to 1. This is equivalent to Intel's Embree.
+/// Intersect a ray with a quad represented as two triangles (0,1,3) and
+/// (2,3,1), with the uv coordinates of the second triangle corrected by u =
+/// 1-u' and v = 1-v' to produce a quad parametrization where u and v go from 0
+/// to 1. This is equivalent to Intel's Embree.
 bool intersect_quad(const ray3f& ray, const vec3f& p0, const vec3f& p1,
     const vec3f& p2, const vec3f& p3, vec2f& uv, float& dist);
 
-// Intersect a ray with a axis-aligned bounding box.
+/// Intersect a ray with a axis-aligned bounding box.
 bool intersect_bbox(const ray3f& ray, const bbox3f& bbox);
 
-// Intersect a ray with a axis-aligned bounding box, implemented as
-// "Robust BVH Ray Traversal" by T. Ize published at
-// http://jcgt.org/published/0002/02/02/paper.pdf
+/// Intersect a ray with a axis-aligned bounding box, implemented as
+/// "Robust BVH Ray Traversal" by T. Ize published at
+/// http://jcgt.org/published/0002/02/02/paper.pdf
 bool intersect_bbox(const ray3f& ray, const vec3f& ray_dinv,
     const vec3i& ray_dsign, const bbox3f& bbox);
 
-// Intersect a ray with a axis-aligned bounding box, implemented as
-// "A Ray-Box Intersection Algorithm and Efficient Dynamic Voxel Rendering" at
-// http://jcgt.org/published/0007/03/04/
-// but using the Wald implementation
+/// Intersect a ray with a axis-aligned bounding box, implemented as
+/// "A Ray-Box Intersection Algorithm and Efficient Dynamic Voxel Rendering" at
+/// http://jcgt.org/published/0007/03/04/
+/// but using the Wald implementation
 bool intersect_bbox(const ray3f& ray, const vec3f& ray_dinv,
     const vec3i& ray_dsign, const bbox3f& bbox);
 
-// Check if a point overlaps a position within a max distance.
+/// Check if a point overlaps a position within a max distance.
 bool overlap_point(const vec3f& pos, float dist_max, const vec3f& p0, float r0,
     vec2f& uv, float& dist);
 
-// Find closest line point to a position.
+/// Find closest line point to a position.
 float closestuv_line(const vec3f& pos, const vec3f& p0, const vec3f& p1);
 
-// Check if a line overlaps a position within a max distance.
+/// Check if a line overlaps a position within a max distance.
 bool overlap_line(const vec3f& pos, float dist_max, const vec3f& p0,
     const vec3f& p1, float r0, float r1, vec2f& uv, float& dist);
 
-// Find closest triangle point to a position.
+/// Find closest triangle point to a position.
 vec2f closestuv_triangle(
     const vec3f& pos, const vec3f& p0, const vec3f& p1, const vec3f& p2);
 
-// Check if a triangle overlaps a position within a max distance.
+/// Check if a triangle overlaps a position within a max distance.
 bool overlap_triangle(const vec3f& pos, float dist_max, const vec3f& p0,
     const vec3f& p1, const vec3f& p2, float r0, float r1, float r2, vec2f& uv,
     float& dist);
 
-// Check if a quad overlaps a position within a max distance.
+/// Check if a quad overlaps a position within a max distance.
 bool overlap_quad(const vec3f& pos, float dist_max, const vec3f& p0,
     const vec3f& p1, const vec3f& p2, const vec3f& p3, float r0, float r1,
     float r2, float r3, vec2f& uv, float& dist);
 
-// Check if a bounding box overlaps a position within a max distance.
+/// Check if a bounding box overlaps a position within a max distance.
 bool overlap_bbox(const vec3f& pos, float dist_max, const bbox3f& bbox);
 
-// Check if two bounding boxes overlap.
+/// Check if two bounding boxes overlap.
 bool overlap_bbox(const bbox3f& bbox1, const bbox3f& bbox2);
 
 }  // namespace yocto

--- a/yocto/yocto_image.h
+++ b/yocto/yocto_image.h
@@ -1,37 +1,37 @@
-//
-// # Yocto/Image: Tiny imaging Library mostly for rendering and color support
-//
-//
-// Yocto/Image is a collection of image utilities useful when writing rendering
-// algorithms. These include a simple image data structure, color conversion
-// utilities and tone mapping. We provinde loading and saving functionality for
-// images and support PNG, JPG, TGA, BMP, HDR, EXR formats.
-//
-// This library depends on stb_image.h, stb_image_write.h, stb_image_resize.h,
-// tinyexr.h for the IO features. If thoese are not needed, it can be safely
-// used without dependencies.
-//
-//
-// ## Image Utilities
-//
-// Yocto/Image supports a very small set of color and image utilities including
-// color utilities, example image creation, tone mapping, image resizing, and
-// sunsky procedural images. Yocto/Image is written to support the need of a
-// global illumination renderer, rather than the need of generic image editing.
-// We support 4-channels float images (assumed to be in linear color) and
-// 4-channels byte images (assumed to be in sRGB).
-//
-//
-// 1. store images using the image<T> structure
-// 2. load and save images with `load_image()` and `save_image()`
-// 3. resize images with `resize()`
-// 4. tonemap images with `tonemap()` that convert from linear HDR to
-//    sRGB LDR with exposure and an optional filmic curve
-// 5. make various image examples with the `make_proc_image()` functions
-// 6. create procedural sun-sky images with `make_sunsky()`
-// 7. many color conversion functions are available in the code below
-//
-//
+///
+/// # Yocto/Image: Tiny imaging Library mostly for rendering and color support
+///
+///
+/// Yocto/Image is a collection of image utilities useful when writing rendering
+/// algorithms. These include a simple image data structure, color conversion
+/// utilities and tone mapping. We provinde loading and saving functionality for
+/// images and support PNG, JPG, TGA, BMP, HDR, EXR formats.
+///
+/// This library depends on stb_image.h, stb_image_write.h, stb_image_resize.h,
+/// tinyexr.h for the IO features. If thoese are not needed, it can be safely
+/// used without dependencies.
+///
+///
+/// ## Image Utilities
+///
+/// Yocto/Image supports a very small set of color and image utilities including
+/// color utilities, example image creation, tone mapping, image resizing, and
+/// sunsky procedural images. Yocto/Image is written to support the need of a
+/// global illumination renderer, rather than the need of generic image editing.
+/// We support 4-channels float images (assumed to be in linear color) and
+/// 4-channels byte images (assumed to be in sRGB).
+///
+///
+/// 1. store images using the image<T> structure
+/// 2. load and save images with `load_image()` and `save_image()`
+/// 3. resize images with `resize()`
+/// 4. tonemap images with `tonemap()` that convert from linear HDR to
+///    sRGB LDR with exposure and an optional filmic curve
+/// 5. make various image examples with the `make_proc_image()` functions
+/// 6. create procedural sun-sky images with `make_sunsky()`
+/// 7. many color conversion functions are available in the code below
+///
+///
 
 //
 // LICENSE:
@@ -96,7 +96,7 @@
 // -----------------------------------------------------------------------------
 namespace yocto {
 
-// Image container.
+/// Image container.
 template <typename T>
 struct image {
   // constructors
@@ -106,7 +106,7 @@ struct image {
   image(const vec2i& size, const T* value)
       : extent{size}, pixels(value, value + (size_t)size.x * (size_t)size.y) {}
 
-  // size
+  /// size
   bool   empty() const { return pixels.empty(); }
   vec2i  size() const { return extent; }
   size_t count() const { return pixels.size(); }
@@ -124,7 +124,7 @@ struct image {
   }
   void shrink_to_fit() { pixels.shrink_to_fit(); }
 
-  // element access
+  /// element access
   T&       operator[](int i) { return pixels[i]; }
   const T& operator[](int i) const { return pixels[i]; }
   T& operator[](const vec2i& ij) { return pixels[ij.y * extent.x + ij.x]; }
@@ -132,23 +132,23 @@ struct image {
     return pixels[ij.y * extent.x + ij.x];
   }
 
-  // data access
+  /// data access
   T*       data() { return pixels.data(); }
   const T* data() const { return pixels.data(); }
 
-  // iteration
+  /// iteration
   T*       begin() { return pixels.data(); }
   T*       end() { return pixels.data() + pixels.size(); }
   const T* begin() const { return pixels.data(); }
   const T* end() const { return pixels.data() + pixels.size(); }
 
  private:
-  // data
+  /// data
   vec2i     extent = zero2i;
   vector<T> pixels = {};
 };
 
-// equality
+/// equality
 template <typename T>
 inline bool operator==(const image<T>& a, const image<T>& b) {
   return a.size() == b.size() && a.pixels == b.pixels;
@@ -165,7 +165,7 @@ inline bool operator!=(const image<T>& a, const image<T>& b) {
 // -----------------------------------------------------------------------------
 namespace yocto {
 
-// Image region
+/// Image region
 struct image_region {
   vec2i min = zero2i;
   vec2i max = zero2i;
@@ -176,11 +176,11 @@ struct image_region {
   vec2i size() const { return max - min; }
 };
 
-// Splits an image into an array of regions
+/// Splits an image into an array of regions
 vector<image_region> make_regions(
     const vec2i& size, int region_size = 32, bool shuffled = false);
 
-// Gets pixels in an image region
+/// Gets pixels in an image region
 template <typename T>
 inline image<T> get_region(const image<T>& img, const image_region& region) {
   auto clipped = image<T>{region.size()};
@@ -212,13 +212,13 @@ inline void get_region(
   }
 }
 
-// Conversion from/to floats.
+/// Conversion from/to floats.
 image<vec4f> byte_to_float(const image<vec4b>& bt);
 image<vec4b> float_to_byte(const image<vec4f>& fl);
 void         byte_to_float(image<vec4f>& fl, const image<vec4b>& bt);
 void         float_to_byte(image<vec4b>& bt, const image<vec4f>& fl);
 
-// Conversion between linear and gamma-encoded images.
+/// Conversion between linear and gamma-encoded images.
 image<vec4f> srgb_to_rgb(const image<vec4f>& srgb);
 image<vec4f> rgb_to_srgb(const image<vec4f>& rgb);
 image<vec4f> srgb_to_rgb(const image<vec4b>& srgb);
@@ -226,7 +226,7 @@ image<vec4b> rgb_to_srgbb(const image<vec4f>& rgb);
 void         srgb_to_rgb(image<vec4f>& rgb, const image<vec4f>& srgb);
 void         rgb_to_srgb(image<vec4f>& srgb, const image<vec4f>& rgb);
 
-// Tone mapping params
+/// Tone mapping params
 struct tonemap_params {
   float exposure    = 0;
   vec3f tint        = {1, 1, 1};
@@ -237,7 +237,7 @@ struct tonemap_params {
   bool  srgb        = true;
 };
 
-// Equality operators
+/// Equality operators
 inline bool operator==(const tonemap_params& a, const tonemap_params& b) {
   return memcmp(&a, &b, sizeof(a)) == 0;
 }
@@ -245,13 +245,13 @@ inline bool operator!=(const tonemap_params& a, const tonemap_params& b) {
   return memcmp(&a, &b, sizeof(a)) != 0;
 }
 
-// Apply exposure and filmic tone mapping
+/// Apply exposure and filmic tone mapping
 image<vec4f> tonemap(const image<vec4f>& hdr, const tonemap_params& params);
 image<vec4b> tonemapb(const image<vec4f>& hdr, const tonemap_params& params);
 void         tonemap(image<vec4f>& ldr, const image<vec4f>& hdr,
             const image_region& region, const tonemap_params& params);
 
-// minimal color grading
+/// minimal color grading
 struct colorgrade_params {
   float contrast         = 0.5;
   float shadows          = 0.5;
@@ -262,7 +262,7 @@ struct colorgrade_params {
   vec3f highlights_color = {1, 1, 1};
 };
 
-// Equality operators
+/// Equality operators
 inline bool operator==(const colorgrade_params& a, const colorgrade_params& b) {
   return memcmp(&a, &b, sizeof(a)) == 0;
 }
@@ -270,16 +270,16 @@ inline bool operator!=(const colorgrade_params& a, const colorgrade_params& b) {
   return memcmp(&a, &b, sizeof(a)) != 0;
 }
 
-// color grade an image region
+/// color grade an image region
 image<vec4f> colorgrade(
     const image<vec4f>& img, const colorgrade_params& params);
 void colorgrade(image<vec4f>& corrected, const image<vec4f>& img,
     const image_region& region, const colorgrade_params& params);
 
-// determine white balance colors
+/// determine white balance colors
 vec3f compute_white_balance(const image<vec4f>& img);
 
-// Resize an image.
+/// Resize an image.
 image<vec4f> resize(const image<vec4f>& img, const vec2i& size);
 image<vec4b> resize(const image<vec4b>& img, const vec2i& size);
 void resize(image<vec4f>& res, const image<vec4f>& img, const vec2i& size);
@@ -292,10 +292,10 @@ void resize(image<vec4b>& res, const image<vec4b>& img, const vec2i& size);
 // -----------------------------------------------------------------------------
 namespace yocto {
 
-// Check if an image is HDR based on filename.
+/// Check if an image is HDR based on filename.
 bool is_hdr_filename(const string& filename);
 
-// Loads/saves a 4 channels float/byte image in linear color space.
+/// Loads/saves a 4 channels float/byte image in linear color space.
 image<vec4f> load_image(const string& filename);
 void         load_image(const string& filename, image<vec4f>& img);
 void         save_image(const string& filename, const image<vec4f>& img);
@@ -310,39 +310,39 @@ void         save_imageb(const string& filename, const image<vec4b>& img);
 // -----------------------------------------------------------------------------
 namespace yocto {
 
-// Parameters for make_proc_image
+/// Parameters for make_proc_image
 struct proc_image_params {
-  // clang-format off
+  /// clang-format off
   enum struct type_t {
     grid, checker, bumps, ramp, gammaramp, uvramp, uvgrid, blackbody, noise,
     turbulence, fbm, ridge };
-  // clang-format on
+  /// clang-format on
   type_t type    = type_t::grid;
   vec2i  size    = {1024, 1024};
   float  scale   = 1;
   vec4f  color0  = {0, 0, 0, 1};
   vec4f  color1  = {1, 1, 1, 1};
-  vec4f  noise   = {2, 0.5, 8, 1};  // lacunarity, gain, octaves, offset
+  vec4f  noise   = {2, 0.5, 8, 1};  /// lacunarity, gain, octaves, offset
   float  borderw = 0;
   vec4f  borderc = {0, 0, 0, 1};
 };
 
-// Make an image
+/// Make an image
 image<vec4f> make_proc_image(const proc_image_params& params);
 void make_proc_image(image<vec4f>& img, const proc_image_params& params);
 
-// Make a sunsky HDR model with sun at sun_angle elevation in [0,pif/2],
-// turbidity in [1.7,10] with or without sun. The sun can be enabled or
-// disabled with has_sun. The sun parameters can be slightly modified by
-// changing the sun intensity and temperature. Has a convention, a temperature
-// of 0 sets the eath sun defaults (ignoring intensity too).
+/// Make a sunsky HDR model with sun at sun_angle elevation in [0,pif/2],
+/// turbidity in [1.7,10] with or without sun. The sun can be enabled or
+/// disabled with has_sun. The sun parameters can be slightly modified by
+/// changing the sun intensity and temperature. Has a convention, a temperature
+/// of 0 sets the eath sun defaults (ignoring intensity too).
 image<vec4f> make_sunsky(const vec2i& size, float sun_angle,
     float turbidity = 3, bool has_sun = false, float sun_intensity = 1,
     float sun_radius = 1, const vec3f& ground_albedo = {0.2, 0.2, 0.2});
 void         make_sunsky(image<vec4f>& img, const vec2i& size, float sun_angle,
             float turbidity = 3, bool has_sun = false, float sun_intensity = 1,
             float sun_radius = 1, const vec3f& ground_albedo = {0.2, 0.2, 0.2});
-// Make an image of multiple lights.
+/// Make an image of multiple lights.
 image<vec4f> make_lights(const vec2i& size, const vec3f& le = {1, 1, 1},
     int nlights = 4, float langle = pif / 4, float lwidth = pif / 16,
     float lheight = pif / 16);
@@ -350,17 +350,17 @@ void         make_lights(image<vec4f>& img, const vec2i& size,
             const vec3f& le = {1, 1, 1}, int nlights = 4, float langle = pif / 4,
             float lwidth = pif / 16, float lheight = pif / 16);
 
-// Comvert a bump map to a normal map. All linear color spaces.
+/// Comvert a bump map to a normal map. All linear color spaces.
 image<vec4f> bump_to_normal(const image<vec4f>& img, float scale = 1);
 void         bump_to_normal(
             image<vec4f>& norm, const image<vec4f>& img, float scale = 1);
 
-// Add a border to an image
+/// Add a border to an image
 image<vec4f> add_border(const image<vec4f>& img, int width, const vec4f& color);
 void         add_border(
             image<vec4f>& bordered, image<vec4f>& img, int width, const vec4f& color);
 
-// Make logo images. Image is resized to proper size.
+/// Make logo images. Image is resized to proper size.
 image<vec4b> make_logo(const string& name);
 void         make_logo(image<vec4f>& img, const string& name);
 void         make_logo(image<vec4b>& img, const string& name);
@@ -373,7 +373,7 @@ void add_logo(image<vec4f>& with_logo, const image<vec4f>& img,
 void add_logo(image<vec4b>& with_logo, const image<vec4b>& img,
     const string& name = "logo-medium");
 
-// Make an image preset, useful for testing. See implementation for types.
+/// Make an image preset, useful for testing. See implementation for types.
 image<vec4f> make_image_preset(const string& type);
 void         make_image_preset(image<vec4f>& img, const string& type);
 void         make_image_preset(image<vec4b>& img, const string& type);
@@ -387,10 +387,10 @@ void         make_image_preset(
 // -----------------------------------------------------------------------------
 namespace yocto {
 
-// Volume container.
+/// Volume container.
 template <typename T>
 struct volume {
-  // constructors
+  /// constructors
   volume() : extent{0, 0, 0}, voxels{} {}
   volume(const vec3i& size, const T& value)
       : extent{size}
@@ -400,7 +400,7 @@ struct volume {
       , voxels(
             value, value + (size_t)size.x * (size_t)size.y * (size_t)size.z) {}
 
-  // size
+  /// size
   bool   empty() const { return voxels.empty(); }
   vec3i  size() const { return extent; }
   size_t count() const { return voxels.size(); }
@@ -415,7 +415,7 @@ struct volume {
   }
   void shrink_to_fit() { voxels.shrink_to_fit(); }
 
-  // element access
+  /// element access
   T&       operator[](size_t i) { return voxels[i]; }
   const T& operator[](size_t i) const { return voxels[i]; }
   T&       operator[](const vec3i& ijk) {
@@ -425,23 +425,23 @@ struct volume {
     return voxels[ijk.z * extent.x * extent.y + ijk.y * extent.x + ijk.x];
   }
 
-  // data access
+  /// data access
   T*       data() { return voxels.data(); }
   const T* data() const { return voxels.data(); }
 
-  // iteration
+  /// iteration
   T*       begin() { return voxels.data(); }
   T*       end() { return voxels.data() + voxels.size(); }
   const T* begin() const { return voxels.data(); }
   const T* end() const { return voxels.data() + voxels.size(); }
 
  private:
-  // data
+  /// data
   vec3i         extent = zero3i;
   vector<float> voxels = {};
 };
 
-// equality
+/// equality
 template <typename T>
 inline bool operator==(const volume<T>& a, const volume<T>& b) {
   return a.size() == b.size() && a.voxels == b.voxels;
@@ -451,7 +451,7 @@ inline bool operator!=(const volume<T>& a, const volume<T>& b) {
   return a.size() != b.size() || a.voxels != b.voxels;
 }
 
-// make a simple example volume
+/// make a simple example volume
 void make_voltest(volume<float>& vol, const vec3i& size, float scale = 10,
     float exponent = 6);
 void make_volpreset(volume<float>& vol, const string& type);
@@ -462,7 +462,7 @@ void make_volpreset(volume<float>& vol, const string& type);
 // -----------------------------------------------------------------------------
 namespace yocto {
 
-// Loads/saves a 1 channel volume.
+/// Loads/saves a 1 channel volume.
 void load_volume(const string& filename, volume<float>& vol);
 void save_volume(const string& filename, const volume<float>& vol);
 
@@ -473,7 +473,7 @@ void save_volume(const string& filename, const volume<float>& vol);
 // -----------------------------------------------------------------------------
 namespace yocto {
 
-// Conversion between flots and bytes
+/// Conversion between flots and bytes
 inline vec4b float_to_byte(const vec4f& a) {
   return {(byte)clamp(int(a.x * 256), 0, 255),
       (byte)clamp(int(a.y * 256), 0, 255), (byte)clamp(int(a.z * 256), 0, 255),
@@ -483,12 +483,12 @@ inline vec4f byte_to_float(const vec4b& a) {
   return {a.x / 255.0f, a.y / 255.0f, a.z / 255.0f, a.w / 255.0f};
 }
 
-// Luminance
+/// Luminance
 inline float luminance(const vec3f& a) {
   return (0.2126f * a.x + 0.7152f * a.y + 0.0722f * a.z);
 }
 
-// sRGB non-linear curve
+/// sRGB non-linear curve
 inline float srgb_to_rgb(float srgb) {
   return (srgb <= 0.04045) ? srgb / 12.92f
                            : pow((srgb + 0.055f) / (1.0f + 0.055f), 2.4f);
@@ -511,11 +511,11 @@ inline vec4f rgb_to_srgb(const vec4f& rgb) {
   return {rgb_to_srgb(rgb.x), rgb_to_srgb(rgb.y), rgb_to_srgb(rgb.z), rgb.w};
 }
 
-// Apply contrast. Grey should be 0.18 for linear and 0.5 for gamma.
+/// Apply contrast. Grey should be 0.18 for linear and 0.5 for gamma.
 inline vec3f contrast(const vec3f& rgb, float contrast, float grey) {
   return max(zero3f, grey + (rgb - grey) * (contrast * 2));
 }
-// Apply contrast in log2. Grey should be 0.18 for linear and 0.5 for gamma.
+/// Apply contrast in log2. Grey should be 0.18 for linear and 0.5 for gamma.
 inline vec3f logcontrast(const vec3f& rgb, float logcontrast, float grey) {
   auto epsilon  = (float)0.0001;
   auto log_grey = log2(grey);
@@ -523,16 +523,16 @@ inline vec3f logcontrast(const vec3f& rgb, float logcontrast, float grey) {
   auto adjusted = log_grey + (log_ldr - log_grey) * (logcontrast * 2);
   return max(zero3f, exp2(adjusted) - epsilon);
 }
-// Apply saturation.
+/// Apply saturation.
 inline vec3f saturate(const vec3f& rgb, float saturation,
     const vec3f& weights = vec3f{0.333333f}) {
   auto grey = dot(weights, rgb);
   return max(zero3f, grey + (rgb - grey) * (saturation * 2));
 }
 
-// Convert between CIE XYZ and RGB
+/// Convert between CIE XYZ and RGB
 inline vec3f rgb_to_xyz(const vec3f& rgb) {
-  // https://en.wikipedia.org/wiki/SRGB
+  /// https://en.wikipedia.org/wiki/SRGB
   static const auto mat = mat3f{
       {0.4124, 0.2126, 0.0193},
       {0.3576, 0.7152, 0.1192},
@@ -541,7 +541,7 @@ inline vec3f rgb_to_xyz(const vec3f& rgb) {
   return mat * rgb;
 }
 inline vec3f xyz_to_rgb(const vec3f& xyz) {
-  // https://en.wikipedia.org/wiki/SRGB
+  /// https://en.wikipedia.org/wiki/SRGB
   static const auto mat = mat3f{
       {+3.2406, -0.9689, +0.0557},
       {-1.5372, +1.8758, -0.2040},
@@ -550,7 +550,7 @@ inline vec3f xyz_to_rgb(const vec3f& xyz) {
   return mat * xyz;
 }
 
-// Convert between CIE XYZ and xyY
+/// Convert between CIE XYZ and xyY
 inline vec3f xyz_to_xyY(const vec3f& xyz) {
   if (xyz == zero3f) return zero3f;
   return {
@@ -561,34 +561,34 @@ inline vec3f xyY_to_xyz(const vec3f& xyY) {
   return {xyY.x * xyY.z / xyY.y, xyY.z, (1 - xyY.x - xyY.y) * xyY.z / xyY.y};
 }
 
-// Approximate color of blackbody radiation from wavelength in nm.
+/// Approximate color of blackbody radiation from wavelength in nm.
 vec3f blackbody_to_rgb(float temperature);
 
-// Converts between HSV and RGB color spaces.
+/// Converts between HSV and RGB color spaces.
 vec3f hsv_to_rgb(const vec3f& hsv);
 vec3f rgb_to_hsv(const vec3f& rgb);
 
-// RGB color spaces
+/// RGB color spaces
 enum struct color_space {
-  rgb,         // default linear space (srgb linear)
-  srgb,        // srgb color space (non-linear)
-  adobe,       // Adobe rgb color space (non-linear)
-  prophoto,    // ProPhoto Kodak rgb color space (non-linear)
-  rec709,      // hdtv color space (non-linear)
-  rec2020,     // uhtv color space (non-linear)
-  rec2100pq,   // hdr color space with perceptual quantizer (non-linear)
-  rec2100hlg,  // hdr color space with hybrid log gamma (non-linear)
-  aces2065,    // ACES storage format (linear)
-  acescg,      // ACES CG computation (linear)
-  acescc,      // ACES color correction (non-linear)
-  acescct,     // ACES color correction 2 (non-linear)
-  p3dci,       // P3 DCI (non-linear)
-  p3d60,       // P3 variation for D60 (non-linear)
-  p3d65,       // P3 variation for D65 (non-linear)
-  p3display,   // Apple display P3
+  rgb,         /// default linear space (srgb linear)
+  srgb,        /// srgb color space (non-linear)
+  adobe,       /// Adobe rgb color space (non-linear)
+  prophoto,    /// ProPhoto Kodak rgb color space (non-linear)
+  rec709,      /// hdtv color space (non-linear)
+  rec2020,     /// uhtv color space (non-linear)
+  rec2100pq,   /// hdr color space with perceptual quantizer (non-linear)
+  rec2100hlg,  /// hdr color space with hybrid log gamma (non-linear)
+  aces2065,    /// ACES storage format (linear)
+  acescg,      /// ACES CG computation (linear)
+  acescc,      /// ACES color correction (non-linear)
+  acescct,     /// ACES color correction 2 (non-linear)
+  p3dci,       /// P3 DCI (non-linear)
+  p3d60,       /// P3 variation for D60 (non-linear)
+  p3d65,       /// P3 variation for D65 (non-linear)
+  p3display,   /// Apple display P3
 };
 
-// Conversion between rgb color spaces
+/// Conversion between rgb color spaces
 vec3f        color_to_xyz(const vec3f& col, color_space from);
 vec3f        xyz_to_color(const vec3f& xyz, color_space to);
 inline vec3f convert_color(const vec3f& col, color_space from, color_space to) {

--- a/yocto/yocto_math.h
+++ b/yocto/yocto_math.h
@@ -1,41 +1,41 @@
-//
-// # Yocto/Math: Tiny library for math support in graphics applications.
-//
-// Yocto/Math provides the basic math primitives used in grahics, including
-// small-sized vectors and matrixes, frames, bounding boxes and transforms.
-//
-// We provide common operations for small vectors and matrices typically used
-// in graphics. In particular, we support 1-4 dimensional vectors
-// coordinates in float and int coordinates (`vec1f`, `vec2f`, `vec3f`, `vec4f`,
-// `vec1i`, `vec2i`, `vec3i`, `vec4i`).
-//
-// We support 2-4 dimensional matrices (`mat2f`, `mat3f`, `mat4f`) with
-// matrix-matrix and matrix-vector products, transposes and inverses.
-// Matrices are stored in column-major order and are accessed and
-// constructed by column. The one dimensional version is for completeness only.
-//
-// To represent transformations, most of the library facilities prefer the use
-// coordinate frames, aka rigid transforms, represented as `frame2f` and
-// `frame3f`. The structure store three coordinate axes and the origin.
-// This is equivalent to a rigid transform written as a column-major affine
-// matrix. Transform operations are fater with this representation.
-//
-// We represent bounding boxes in 2-3 dimensions with `bbox2f`, `bbox3f`
-// Each bounding box support construction from points and other bounding box.
-// We provide operations to compute bounds for points, lines, triangles and
-// quads.
-//
-// For both matrices and frames we support transform operations for points,
-// vectors and directions (`transform_point()`, `transform_vector()`,
-// `transform_direction()`). Transform matrices and frames can be
-// constructed from basic translation, rotation and scaling, e.g. with
-// `translation_mat()` or `translation_frame()` respectively, etc.
-// For rotation we support axis-angle and quaternions, with slerp.
-//
-// Finally, we include a `timer` for benchmarking with high precision and
-// a few common path manipulations ghat will be remove once C++ filesystem
-// support will be more common.
-//
+///
+/// # Yocto/Math: Tiny library for math support in graphics applications.
+///
+/// Yocto/Math provides the basic math primitives used in grahics, including
+/// small-sized vectors and matrixes, frames, bounding boxes and transforms.
+///
+/// We provide common operations for small vectors and matrices typically used
+/// in graphics. In particular, we support 1-4 dimensional vectors
+/// coordinates in float and int coordinates (`vec1f`, `vec2f`, `vec3f`, `vec4f`,
+/// `vec1i`, `vec2i`, `vec3i`, `vec4i`).
+///
+/// We support 2-4 dimensional matrices (`mat2f`, `mat3f`, `mat4f`) with
+/// matrix-matrix and matrix-vector products, transposes and inverses.
+/// Matrices are stored in column-major order and are accessed and
+/// constructed by column. The one dimensional version is for completeness only.
+///
+/// To represent transformations, most of the library facilities prefer the use
+/// coordinate frames, aka rigid transforms, represented as `frame2f` and
+/// `frame3f`. The structure store three coordinate axes and the origin.
+/// This is equivalent to a rigid transform written as a column-major affine
+/// matrix. Transform operations are fater with this representation.
+///
+/// We represent bounding boxes in 2-3 dimensions with `bbox2f`, `bbox3f`
+/// Each bounding box support construction from points and other bounding box.
+/// We provide operations to compute bounds for points, lines, triangles and
+/// quads.
+///
+/// For both matrices and frames we support transform operations for points,
+/// vectors and directions (`transform_point()`, `transform_vector()`,
+/// `transform_direction()`). Transform matrices and frames can be
+/// constructed from basic translation, rotation and scaling, e.g. with
+/// `translation_mat()` or `translation_frame()` respectively, etc.
+/// For rotation we support axis-angle and quaternions, with slerp.
+///
+/// Finally, we include a `timer` for benchmarking with high precision and
+/// a few common path manipulations ghat will be remove once C++ filesystem
+/// support will be more common.
+///
 
 //
 // LICENSE:
@@ -87,7 +87,7 @@
 // -----------------------------------------------------------------------------
 namespace yocto {
 
-// Aliased typenames for readability
+/// Aliased typenames for readability
 using std::pair;
 using std::string;
 using std::unordered_map;
@@ -192,16 +192,16 @@ struct vec4f {
   const float& operator[](int i) const { return (&x)[i]; }
 };
 
-// Zero vector constants.
+/// Zero vector constants.
 inline const auto zero2f = vec2f{0, 0};
 inline const auto zero3f = vec3f{0, 0, 0};
 inline const auto zero4f = vec4f{0, 0, 0, 0};
 
-// Element access
+/// Element access
 inline vec3f&       xyz(vec4f& a) { return (vec3f&)a; }
 inline const vec3f& xyz(const vec4f& a) { return (const vec3f&)a; }
 
-// Vector comparison operations.
+/// Vector comparison operations.
 inline bool operator==(const vec2f& a, const vec2f& b) {
   return a.x == b.x && a.y == b.y;
 }
@@ -209,7 +209,7 @@ inline bool operator!=(const vec2f& a, const vec2f& b) {
   return a.x != b.x || a.y != b.y;
 }
 
-// Vector operations.
+/// Vector operations.
 inline vec2f operator+(const vec2f& a) { return a; }
 inline vec2f operator-(const vec2f& a) { return {-a.x, -a.y}; }
 inline vec2f operator+(const vec2f& a, const vec2f& b) {
@@ -233,7 +233,7 @@ inline vec2f operator/(const vec2f& a, const vec2f& b) {
 inline vec2f operator/(const vec2f& a, float b) { return {a.x / b, a.y / b}; }
 inline vec2f operator/(float a, const vec2f& b) { return {a / b.x, a / b.y}; }
 
-// Vector assignments
+/// Vector assignments
 inline vec2f& operator+=(vec2f& a, const vec2f& b) { return a = a + b; }
 inline vec2f& operator+=(vec2f& a, float b) { return a = a + b; }
 inline vec2f& operator-=(vec2f& a, const vec2f& b) { return a = a - b; }
@@ -243,7 +243,7 @@ inline vec2f& operator*=(vec2f& a, float b) { return a = a * b; }
 inline vec2f& operator/=(vec2f& a, const vec2f& b) { return a = a / b; }
 inline vec2f& operator/=(vec2f& a, float b) { return a = a / b; }
 
-// Vector products and lengths.
+/// Vector products and lengths.
 inline float dot(const vec2f& a, const vec2f& b) {
   return a.x * b.x + a.y * b.y;
 }
@@ -261,7 +261,7 @@ inline float distance_squared(const vec2f& a, const vec2f& b) {
   return dot(a - b, a - b);
 }
 
-// Max element and clamp.
+/// Max element and clamp.
 inline vec2f max(const vec2f& a, float b) { return {max(a.x, b), max(a.y, b)}; }
 inline vec2f min(const vec2f& a, float b) { return {min(a.x, b), min(a.y, b)}; }
 inline vec2f max(const vec2f& a, const vec2f& b) {
@@ -285,7 +285,7 @@ inline float min(const vec2f& a) { return min(a.x, a.y); }
 inline float sum(const vec2f& a) { return a.x + a.y; }
 inline float mean(const vec2f& a) { return sum(a) / 2; }
 
-// Functions applied to vector elements
+/// Functions applied to vector elements
 inline vec2f abs(const vec2f& a) { return {abs(a.x), abs(a.y)}; };
 inline vec2f sqrt(const vec2f& a) { return {sqrt(a.x), sqrt(a.y)}; };
 inline vec2f exp(const vec2f& a) { return {exp(a.x), exp(a.y)}; };
@@ -304,7 +304,7 @@ inline vec2f gain(const vec2f& a, float b) {
 };
 inline void swap(vec2f& a, vec2f& b) { std::swap(a, b); }
 
-// Vector comparison operations.
+/// Vector comparison operations.
 inline bool operator==(const vec3f& a, const vec3f& b) {
   return a.x == b.x && a.y == b.y && a.z == b.z;
 }
@@ -312,7 +312,7 @@ inline bool operator!=(const vec3f& a, const vec3f& b) {
   return a.x != b.x || a.y != b.y || a.z != b.z;
 }
 
-// Vector operations.
+/// Vector operations.
 inline vec3f operator+(const vec3f& a) { return a; }
 inline vec3f operator-(const vec3f& a) { return {-a.x, -a.y, -a.z}; }
 inline vec3f operator+(const vec3f& a, const vec3f& b) {
@@ -352,7 +352,7 @@ inline vec3f operator/(float a, const vec3f& b) {
   return {a / b.x, a / b.y, a / b.z};
 }
 
-// Vector assignments
+/// Vector assignments
 inline vec3f& operator+=(vec3f& a, const vec3f& b) { return a = a + b; }
 inline vec3f& operator+=(vec3f& a, float b) { return a = a + b; }
 inline vec3f& operator-=(vec3f& a, const vec3f& b) { return a = a - b; }
@@ -362,7 +362,7 @@ inline vec3f& operator*=(vec3f& a, float b) { return a = a * b; }
 inline vec3f& operator/=(vec3f& a, const vec3f& b) { return a = a / b; }
 inline vec3f& operator/=(vec3f& a, float b) { return a = a / b; }
 
-// Vector products and lengths.
+/// Vector products and lengths.
 inline float dot(const vec3f& a, const vec3f& b) {
   return a.x * b.x + a.y * b.y + a.z * b.z;
 }
@@ -384,7 +384,7 @@ inline float angle(const vec3f& a, const vec3f& b) {
   return acos(clamp(dot(normalize(a), normalize(b)), (float)-1, (float)1));
 }
 
-// Orthogonal vectors.
+/// Orthogonal vectors.
 inline vec3f orthogonal(const vec3f& v) {
   // http://lolengine.net/blog/2013/09/21/picking-orthogonal-vector-combing-coconuts)
   return abs(v.x) > abs(v.z) ? vec3f{-v.y, v.x, 0} : vec3f{0, -v.z, v.y};
@@ -393,7 +393,7 @@ inline vec3f orthonormalize(const vec3f& a, const vec3f& b) {
   return normalize(a - b * dot(a, b));
 }
 
-// Reflected and refracted vector.
+/// Reflected and refracted vector.
 inline vec3f reflect(const vec3f& w, const vec3f& n) {
   return -w + 2 * dot(n, w) * n;
 }
@@ -404,7 +404,7 @@ inline vec3f refract(const vec3f& w, const vec3f& n, float eta) {
   return -w * eta + (eta * dot(n, w) - sqrt(k)) * n;
 }
 
-// Max element and clamp.
+/// Max element and clamp.
 inline vec3f max(const vec3f& a, float b) {
   return {max(a.x, b), max(a.y, b), max(a.z, b)};
 }
@@ -432,7 +432,7 @@ inline float min(const vec3f& a) { return min(min(a.x, a.y), a.z); }
 inline float sum(const vec3f& a) { return a.x + a.y + a.z; }
 inline float mean(const vec3f& a) { return sum(a) / 3; }
 
-// Functions applied to vector elements
+/// Functions applied to vector elements
 inline vec3f abs(const vec3f& a) { return {abs(a.x), abs(a.y), abs(a.z)}; };
 inline vec3f sqrt(const vec3f& a) { return {sqrt(a.x), sqrt(a.y), sqrt(a.z)}; };
 inline vec3f exp(const vec3f& a) { return {exp(a.x), exp(a.y), exp(a.z)}; };
@@ -453,7 +453,7 @@ inline bool isfinite(const vec3f& a) {
 };
 inline void swap(vec3f& a, vec3f& b) { std::swap(a, b); }
 
-// Vector comparison operations.
+/// Vector comparison operations.
 inline bool operator==(const vec4f& a, const vec4f& b) {
   return a.x == b.x && a.y == b.y && a.z == b.z && a.w == b.w;
 }
@@ -461,7 +461,7 @@ inline bool operator!=(const vec4f& a, const vec4f& b) {
   return a.x != b.x || a.y != b.y || a.z != b.z || a.w != b.w;
 }
 
-// Vector operations.
+/// Vector operations.
 inline vec4f operator+(const vec4f& a) { return a; }
 inline vec4f operator-(const vec4f& a) { return {-a.x, -a.y, -a.z, -a.w}; }
 inline vec4f operator+(const vec4f& a, const vec4f& b) {
@@ -501,7 +501,7 @@ inline vec4f operator/(float a, const vec4f& b) {
   return {a / b.x, a / b.y, a / b.z, a / b.w};
 }
 
-// Vector assignments
+/// Vector assignments
 inline vec4f& operator+=(vec4f& a, const vec4f& b) { return a = a + b; }
 inline vec4f& operator+=(vec4f& a, float b) { return a = a + b; }
 inline vec4f& operator-=(vec4f& a, const vec4f& b) { return a = a - b; }
@@ -511,7 +511,7 @@ inline vec4f& operator*=(vec4f& a, float b) { return a = a * b; }
 inline vec4f& operator/=(vec4f& a, const vec4f& b) { return a = a / b; }
 inline vec4f& operator/=(vec4f& a, float b) { return a = a / b; }
 
-// Vector products and lengths.
+/// Vector products and lengths.
 inline float dot(const vec4f& a, const vec4f& b) {
   return a.x * b.x + a.y * b.y + a.z * b.z + a.w * b.w;
 }
@@ -539,7 +539,7 @@ inline vec4f slerp(const vec4f& a, const vec4f& b, float u) {
   return an * (sin(th * (1 - u)) / sin(th)) + bn * (sin(th * u) / sin(th));
 }
 
-// Max element and clamp.
+/// Max element and clamp.
 inline vec4f max(const vec4f& a, float b) {
   return {max(a.x, b), max(a.y, b), max(a.z, b), max(a.w, b)};
 }
@@ -568,7 +568,7 @@ inline float min(const vec4f& a) { return min(min(min(a.x, a.y), a.z), a.w); }
 inline float sum(const vec4f& a) { return a.x + a.y + a.z + a.w; }
 inline float mean(const vec4f& a) { return sum(a) / 4; }
 
-// Functions applied to vector elements
+/// Functions applied to vector elements
 inline vec4f abs(const vec4f& a) {
   return {abs(a.x), abs(a.y), abs(a.z), abs(a.w)};
 };
@@ -601,8 +601,8 @@ inline bool isfinite(const vec4f& a) {
 };
 inline void swap(vec4f& a, vec4f& b) { std::swap(a, b); }
 
-// Quaternion operatons represented as xi + yj + zk + w
-// const auto identity_quat4f = vec4f{0, 0, 0, 1};
+/// Quaternion operatons represented as xi + yj + zk + w
+/// const auto identity_quat4f = vec4f{0, 0, 0, 1};
 inline vec4f quat_mul(const vec4f& a, float b) {
   return {a.x * b, a.y * b, a.z * b, a.w * b};
 }
@@ -679,17 +679,17 @@ struct vec4b {
   const byte& operator[](int i) const { return (&x)[i]; }
 };
 
-// Zero vector constants.
+/// Zero vector constants.
 inline const auto zero2i = vec2i{0, 0};
 inline const auto zero3i = vec3i{0, 0, 0};
 inline const auto zero4i = vec4i{0, 0, 0, 0};
 inline const auto zero4b = vec4b{0, 0, 0, 0};
 
-// Element access
+/// Element access
 inline vec3i&       xyz(vec4i& a) { return (vec3i&)a; }
 inline const vec3i& xyz(const vec4i& a) { return (const vec3i&)a; }
 
-// Vector comparison operations.
+/// Vector comparison operations.
 inline bool operator==(const vec2i& a, const vec2i& b) {
   return a.x == b.x && a.y == b.y;
 }
@@ -697,7 +697,7 @@ inline bool operator!=(const vec2i& a, const vec2i& b) {
   return a.x != b.x || a.y != b.y;
 }
 
-// Vector operations.
+/// Vector operations.
 inline vec2i operator+(const vec2i& a) { return a; }
 inline vec2i operator-(const vec2i& a) { return {-a.x, -a.y}; }
 inline vec2i operator+(const vec2i& a, const vec2i& b) {
@@ -721,7 +721,7 @@ inline vec2i operator/(const vec2i& a, const vec2i& b) {
 inline vec2i operator/(const vec2i& a, int b) { return {a.x / b, a.y / b}; }
 inline vec2i operator/(int a, const vec2i& b) { return {a / b.x, a / b.y}; }
 
-// Vector assignments
+/// Vector assignments
 inline vec2i& operator+=(vec2i& a, const vec2i& b) { return a = a + b; }
 inline vec2i& operator+=(vec2i& a, int b) { return a = a + b; }
 inline vec2i& operator-=(vec2i& a, const vec2i& b) { return a = a - b; }
@@ -731,7 +731,7 @@ inline vec2i& operator*=(vec2i& a, int b) { return a = a * b; }
 inline vec2i& operator/=(vec2i& a, const vec2i& b) { return a = a / b; }
 inline vec2i& operator/=(vec2i& a, int b) { return a = a / b; }
 
-// Max element and clamp.
+/// Max element and clamp.
 inline vec2i max(const vec2i& a, int b) { return {max(a.x, b), max(a.y, b)}; }
 inline vec2i min(const vec2i& a, int b) { return {min(a.x, b), min(a.y, b)}; }
 inline vec2i max(const vec2i& a, const vec2i& b) {
@@ -748,11 +748,11 @@ inline int max(const vec2i& a) { return max(a.x, a.y); }
 inline int min(const vec2i& a) { return min(a.x, a.y); }
 inline int sum(const vec2i& a) { return a.x + a.y; }
 
-// Functions applied to vector elements
+/// Functions applied to vector elements
 inline vec2i abs(const vec2i& a) { return {abs(a.x), abs(a.y)}; };
 inline void  swap(vec2i& a, vec2i& b) { std::swap(a, b); }
 
-// Vector comparison operations.
+/// Vector comparison operations.
 inline bool operator==(const vec3i& a, const vec3i& b) {
   return a.x == b.x && a.y == b.y && a.z == b.z;
 }
@@ -760,7 +760,7 @@ inline bool operator!=(const vec3i& a, const vec3i& b) {
   return a.x != b.x || a.y != b.y || a.z != b.z;
 }
 
-// Vector operations.
+/// Vector operations.
 inline vec3i operator+(const vec3i& a) { return a; }
 inline vec3i operator-(const vec3i& a) { return {-a.x, -a.y, -a.z}; }
 inline vec3i operator+(const vec3i& a, const vec3i& b) {
@@ -800,7 +800,7 @@ inline vec3i operator/(int a, const vec3i& b) {
   return {a / b.x, a / b.y, a / b.z};
 }
 
-// Vector assignments
+/// Vector assignments
 inline vec3i& operator+=(vec3i& a, const vec3i& b) { return a = a + b; }
 inline vec3i& operator+=(vec3i& a, int b) { return a = a + b; }
 inline vec3i& operator-=(vec3i& a, const vec3i& b) { return a = a - b; }
@@ -810,7 +810,7 @@ inline vec3i& operator*=(vec3i& a, int b) { return a = a * b; }
 inline vec3i& operator/=(vec3i& a, const vec3i& b) { return a = a / b; }
 inline vec3i& operator/=(vec3i& a, int b) { return a = a / b; }
 
-// Max element and clamp.
+/// Max element and clamp.
 inline vec3i max(const vec3i& a, int b) {
   return {max(a.x, b), max(a.y, b), max(a.z, b)};
 }
@@ -831,11 +831,11 @@ inline int max(const vec3i& a) { return max(max(a.x, a.y), a.z); }
 inline int min(const vec3i& a) { return min(min(a.x, a.y), a.z); }
 inline int sum(const vec3i& a) { return a.x + a.y + a.z; }
 
-// Functions applied to vector elements
+/// Functions applied to vector elements
 inline vec3i abs(const vec3i& a) { return {abs(a.x), abs(a.y), abs(a.z)}; };
 inline void  swap(vec3i& a, vec3i& b) { std::swap(a, b); }
 
-// Vector comparison operations.
+/// Vector comparison operations.
 inline bool operator==(const vec4i& a, const vec4i& b) {
   return a.x == b.x && a.y == b.y && a.z == b.z && a.w == b.w;
 }
@@ -843,7 +843,7 @@ inline bool operator!=(const vec4i& a, const vec4i& b) {
   return a.x != b.x || a.y != b.y || a.z != b.z || a.w != b.w;
 }
 
-// Vector operations.
+/// Vector operations.
 inline vec4i operator+(const vec4i& a) { return a; }
 inline vec4i operator-(const vec4i& a) { return {-a.x, -a.y, -a.z, -a.w}; }
 inline vec4i operator+(const vec4i& a, const vec4i& b) {
@@ -883,7 +883,7 @@ inline vec4i operator/(int a, const vec4i& b) {
   return {a / b.x, a / b.y, a / b.z, a / b.w};
 }
 
-// Vector assignments
+/// Vector assignments
 inline vec4i& operator+=(vec4i& a, const vec4i& b) { return a = a + b; }
 inline vec4i& operator+=(vec4i& a, int b) { return a = a + b; }
 inline vec4i& operator-=(vec4i& a, const vec4i& b) { return a = a - b; }
@@ -893,7 +893,7 @@ inline vec4i& operator*=(vec4i& a, int b) { return a = a * b; }
 inline vec4i& operator/=(vec4i& a, const vec4i& b) { return a = a / b; }
 inline vec4i& operator/=(vec4i& a, int b) { return a = a / b; }
 
-// Max element and clamp.
+/// Max element and clamp.
 inline vec4i max(const vec4i& a, int b) {
   return {max(a.x, b), max(a.y, b), max(a.z, b), max(a.w, b)};
 }
@@ -915,7 +915,7 @@ inline int max(const vec4i& a) { return max(max(max(a.x, a.y), a.z), a.w); }
 inline int min(const vec4i& a) { return min(min(min(a.x, a.y), a.z), a.w); }
 inline int sum(const vec4i& a) { return a.x + a.y + a.z + a.w; }
 
-// Functions applied to vector elements
+/// Functions applied to vector elements
 inline vec4i abs(const vec4i& a) {
   return {abs(a.x), abs(a.y), abs(a.z), abs(a.w)};
 };
@@ -925,7 +925,7 @@ inline void swap(vec4i& a, vec4i& b) { std::swap(a, b); }
 
 namespace std {
 
-// Hash functor for vector for use with unordered_map
+/// Hash functor for vector for use with unordered_map
 template <>
 struct hash<yocto::vec2i> {
   size_t operator()(const yocto::vec2i& v) const {
@@ -967,7 +967,7 @@ struct hash<yocto::vec4i> {
 // -----------------------------------------------------------------------------
 namespace yocto {
 
-// Small Fixed-size matrices stored in column major format.
+/// Small Fixed-size matrices stored in column major format.
 struct mat2f {
   vec2f x = {1, 0};
   vec2f y = {0, 1};
@@ -979,7 +979,7 @@ struct mat2f {
   const vec2f& operator[](int i) const { return (&x)[i]; }
 };
 
-// Small Fixed-size matrices stored in column major format.
+/// Small Fixed-size matrices stored in column major format.
 struct mat3f {
   vec3f x = {1, 0, 0};
   vec3f y = {0, 1, 0};
@@ -992,7 +992,7 @@ struct mat3f {
   const vec3f& operator[](int i) const { return (&x)[i]; }
 };
 
-// Small Fixed-size matrices stored in column major format.
+/// Small Fixed-size matrices stored in column major format.
 struct mat4f {
   vec4f x = {1, 0, 0, 0};
   vec4f y = {0, 1, 0, 0};
@@ -1007,19 +1007,19 @@ struct mat4f {
   const vec4f& operator[](int i) const { return (&x)[i]; }
 };
 
-// Identity matrices constants.
+/// Identity matrices constants.
 inline const auto identity2x2f = mat2f{{1, 0}, {0, 1}};
 inline const auto identity3x3f = mat3f{{1, 0, 0}, {0, 1, 0}, {0, 0, 1}};
 inline const auto identity4x4f = mat4f{
     {1, 0, 0, 0}, {0, 1, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, 1}};
 
-// Matrix comparisons.
+/// Matrix comparisons.
 inline bool operator==(const mat2f& a, const mat2f& b) {
   return a.x == b.x && a.y == b.y;
 }
 inline bool operator!=(const mat2f& a, const mat2f& b) { return !(a == b); }
 
-// Matrix operations.
+/// Matrix operations.
 inline mat2f operator+(const mat2f& a, const mat2f& b) {
   return {a.x + b.x, a.y + b.y};
 }
@@ -1034,18 +1034,18 @@ inline mat2f operator*(const mat2f& a, const mat2f& b) {
   return {a * b.x, a * b.y};
 }
 
-// Matrix assignments.
+/// Matrix assignments.
 inline mat2f& operator+=(mat2f& a, const mat2f& b) { return a = a + b; }
 inline mat2f& operator*=(mat2f& a, const mat2f& b) { return a = a * b; }
 inline mat2f& operator*=(mat2f& a, float b) { return a = a * b; }
 
-// Matrix diagonals and transposes.
+/// Matrix diagonals and transposes.
 inline vec2f diagonal(const mat2f& a) { return {a.x.x, a.y.y}; }
 inline mat2f transpose(const mat2f& a) {
   return {{a.x.x, a.y.x}, {a.x.y, a.y.y}};
 }
 
-// Matrix adjoints, determinants and inverses.
+/// Matrix adjoints, determinants and inverses.
 inline float determinant(const mat2f& a) { return cross(a.x, a.y); }
 inline mat2f adjoint(const mat2f& a) {
   return {{a.y.y, -a.x.y}, {-a.y.x, a.x.x}};
@@ -1054,13 +1054,13 @@ inline mat2f inverse(const mat2f& a) {
   return adjoint(a) * (1 / determinant(a));
 }
 
-// Matrix comparisons.
+/// Matrix comparisons.
 inline bool operator==(const mat3f& a, const mat3f& b) {
   return a.x == b.x && a.y == b.y && a.z == b.z;
 }
 inline bool operator!=(const mat3f& a, const mat3f& b) { return !(a == b); }
 
-// Matrix operations.
+/// Matrix operations.
 inline mat3f operator+(const mat3f& a, const mat3f& b) {
   return {a.x + b.x, a.y + b.y, a.z + b.z};
 }
@@ -1077,12 +1077,12 @@ inline mat3f operator*(const mat3f& a, const mat3f& b) {
   return {a * b.x, a * b.y, a * b.z};
 }
 
-// Matrix assignments.
+/// Matrix assignments.
 inline mat3f& operator+=(mat3f& a, const mat3f& b) { return a = a + b; }
 inline mat3f& operator*=(mat3f& a, const mat3f& b) { return a = a * b; }
 inline mat3f& operator*=(mat3f& a, float b) { return a = a * b; }
 
-// Matrix diagonals and transposes.
+/// Matrix diagonals and transposes.
 inline vec3f diagonal(const mat3f& a) { return {a.x.x, a.y.y, a.z.z}; }
 inline mat3f transpose(const mat3f& a) {
   return {
@@ -1092,7 +1092,7 @@ inline mat3f transpose(const mat3f& a) {
   };
 }
 
-// Matrix adjoints, determinants and inverses.
+/// Matrix adjoints, determinants and inverses.
 inline float determinant(const mat3f& a) { return dot(a.x, cross(a.y, a.z)); }
 inline mat3f adjoint(const mat3f& a) {
   return transpose(mat3f{cross(a.y, a.z), cross(a.z, a.x), cross(a.x, a.y)});
@@ -1101,9 +1101,9 @@ inline mat3f inverse(const mat3f& a) {
   return adjoint(a) * (1 / determinant(a));
 }
 
-// Constructs a basis from a direction
+/// Constructs a basis from a direction
 inline mat3f basis_fromz(const vec3f& v) {
-  // https://graphics.pixar.com/library/OrthonormalB/paper.pdf
+  /// https://graphics.pixar.com/library/OrthonormalB/paper.pdf
   auto z    = normalize(v);
   auto sign = copysignf(1.0f, z.z);
   auto a    = -1.0f / (sign + z.z);
@@ -1113,13 +1113,13 @@ inline mat3f basis_fromz(const vec3f& v) {
   return {x, y, z};
 }
 
-// Matrix comparisons.
+/// Matrix comparisons.
 inline bool operator==(const mat4f& a, const mat4f& b) {
   return a.x == b.x && a.y == b.y && a.z == b.z && a.w == b.w;
 }
 inline bool operator!=(const mat4f& a, const mat4f& b) { return !(a == b); }
 
-// Matrix operations.
+/// Matrix operations.
 inline mat4f operator+(const mat4f& a, const mat4f& b) {
   return {a.x + b.x, a.y + b.y, a.z + b.z, a.w + b.w};
 }
@@ -1136,12 +1136,12 @@ inline mat4f operator*(const mat4f& a, const mat4f& b) {
   return {a * b.x, a * b.y, a * b.z, a * b.w};
 }
 
-// Matrix assignments.
+/// Matrix assignments.
 inline mat4f& operator+=(mat4f& a, const mat4f& b) { return a = a + b; }
 inline mat4f& operator*=(mat4f& a, const mat4f& b) { return a = a * b; }
 inline mat4f& operator*=(mat4f& a, float b) { return a = a * b; }
 
-// Matrix diagonals and transposes.
+/// Matrix diagonals and transposes.
 inline vec4f diagonal(const mat4f& a) { return {a.x.x, a.y.y, a.z.z, a.w.w}; }
 inline mat4f transpose(const mat4f& a) {
   return {
@@ -1159,7 +1159,7 @@ inline mat4f transpose(const mat4f& a) {
 // -----------------------------------------------------------------------------
 namespace yocto {
 
-// Rigid frames stored as a column-major affine transform matrix.
+/// Rigid frames stored as a column-major affine transform matrix.
 struct frame2f {
   vec2f x = {1, 0};
   vec2f y = {0, 1};
@@ -1177,7 +1177,7 @@ struct frame2f {
   const vec2f& operator[](int i) const { return (&x)[i]; }
 };
 
-// Rigid frames stored as a column-major affine transform matrix.
+/// Rigid frames stored as a column-major affine transform matrix.
 struct frame3f {
   vec3f x = {1, 0, 0};
   vec3f y = {0, 1, 0};
@@ -1200,27 +1200,27 @@ struct frame3f {
   const vec3f& operator[](int i) const { return (&x)[i]; }
 };
 
-// Indentity frames.
+/// Indentity frames.
 inline const auto identity2x3f = frame2f{{1, 0}, {0, 1}, {0, 0}};
 inline const auto identity3x4f = frame3f{
     {1, 0, 0}, {0, 1, 0}, {0, 0, 1}, {0, 0, 0}};
 
-// Frame properties
+/// Frame properties
 inline const mat2f& rotation(const frame2f& a) { return (const mat2f&)a; }
 
-// Frame comparisons.
+/// Frame comparisons.
 inline bool operator==(const frame2f& a, const frame2f& b) {
   return a.x == b.x && a.y == b.y && a.o == b.o;
 }
 inline bool operator!=(const frame2f& a, const frame2f& b) { return !(a == b); }
 
-// Frame composition, equivalent to affine matrix product.
+/// Frame composition, equivalent to affine matrix product.
 inline frame2f operator*(const frame2f& a, const frame2f& b) {
   return {rotation(a) * rotation(b), rotation(a) * b.o + a.o};
 }
 inline frame2f& operator*=(frame2f& a, const frame2f& b) { return a = a * b; }
 
-// Frame inverse, equivalent to rigid affine inverse.
+/// Frame inverse, equivalent to rigid affine inverse.
 inline frame2f inverse(const frame2f& a, bool non_rigid = false) {
   if (non_rigid) {
     auto minv = inverse(rotation(a));
@@ -1231,22 +1231,22 @@ inline frame2f inverse(const frame2f& a, bool non_rigid = false) {
   }
 }
 
-// Frame properties
+/// Frame properties
 inline const mat3f& rotation(const frame3f& a) { return (const mat3f&)a; }
 
-// Frame comparisons.
+/// Frame comparisons.
 inline bool operator==(const frame3f& a, const frame3f& b) {
   return a.x == b.x && a.y == b.y && a.z == b.z && a.o == b.o;
 }
 inline bool operator!=(const frame3f& a, const frame3f& b) { return !(a == b); }
 
-// Frame composition, equivalent to affine matrix product.
+/// Frame composition, equivalent to affine matrix product.
 inline frame3f operator*(const frame3f& a, const frame3f& b) {
   return {rotation(a) * rotation(b), rotation(a) * b.o + a.o};
 }
 inline frame3f& operator*=(frame3f& a, const frame3f& b) { return a = a * b; }
 
-// Frame inverse, equivalent to rigid affine inverse.
+/// Frame inverse, equivalent to rigid affine inverse.
 inline frame3f inverse(const frame3f& a, bool non_rigid = false) {
   if (non_rigid) {
     auto minv = inverse(rotation(a));
@@ -1257,7 +1257,7 @@ inline frame3f inverse(const frame3f& a, bool non_rigid = false) {
   }
 }
 
-// Frame construction from axis.
+/// Frame construction from axis.
 inline frame3f frame_fromz(const vec3f& o, const vec3f& v) {
   // https://graphics.pixar.com/library/OrthonormalB/paper.pdf
   auto z    = normalize(v);
@@ -1282,22 +1282,22 @@ inline frame3f frame_fromzx(const vec3f& o, const vec3f& z_, const vec3f& x_) {
 // -----------------------------------------------------------------------------
 namespace yocto {
 
-// Quaternions to represent rotations
+/// Quaternions to represent rotations
 struct quat4f {
   float x = 0;
   float y = 0;
   float z = 0;
   float w = 0;
 
-  // constructors
+  /// constructors
   quat4f() : x{0}, y{0}, z{0}, w{1} {}
   quat4f(float x, float y, float z, float w) : x{x}, y{y}, z{z}, w{w} {}
 };
 
-// Constants
+/// Constants
 inline const auto identity_quat4f = quat4f{0, 0, 0, 1};
 
-// Quaternion operatons
+/// Quaternion operatons
 inline quat4f operator+(const quat4f& a, const quat4f& b) {
   return {a.x + b.x, a.y + b.y, a.z + b.z, a.w + b.w};
 }
@@ -1314,7 +1314,7 @@ inline quat4f operator*(const quat4f& a, const quat4f& b) {
       a.w * b.w - a.x * b.x - a.y * b.y - a.z * b.z};
 }
 
-// Quaterion operations
+/// Quaterion operations
 inline float dot(const quat4f& a, const quat4f& b) {
   return a.x * b.x + a.y * b.y + a.z * b.z + a.w * b.w;
 }
@@ -1349,7 +1349,7 @@ inline quat4f slerp(const quat4f& a, const quat4f& b, float t) {
 // -----------------------------------------------------------------------------
 namespace yocto {
 
-// Axis aligned bounding box represented as a min/max vector pairs.
+/// Axis aligned bounding box represented as a min/max vector pairs.
 struct bbox2f {
   vec2f min = {flt_max, flt_max};
   vec2f max = {flt_min, flt_min};
@@ -1361,7 +1361,7 @@ struct bbox2f {
   const vec2f& operator[](int i) const { return (&min)[i]; }
 };
 
-// Axis aligned bounding box represented as a min/max vector pairs.
+/// Axis aligned bounding box represented as a min/max vector pairs.
 struct bbox3f {
   vec3f min = {flt_max, flt_max, flt_max};
   vec3f max = {flt_min, flt_min, flt_min};
@@ -1373,15 +1373,15 @@ struct bbox3f {
   const vec3f& operator[](int i) const { return (&min)[i]; }
 };
 
-// Empty bbox constant.
+/// Empty bbox constant.
 inline const auto invalidb2f = bbox2f{};
 inline const auto invalidb3f = bbox3f{};
 
-// Bounding box properties
+/// Bounding box properties
 inline vec2f center(const bbox2f& a) { return (a.min + a.max) / 2; }
 inline vec2f size(const bbox2f& a) { return a.max - a.min; }
 
-// Bounding box comparisons.
+/// Bounding box comparisons.
 inline bool operator==(const bbox2f& a, const bbox2f& b) {
   return a.min == b.min && a.max == b.max;
 }
@@ -1389,7 +1389,7 @@ inline bool operator!=(const bbox2f& a, const bbox2f& b) {
   return a.min != b.min || a.max != b.max;
 }
 
-// Bounding box expansions with points and other boxes.
+/// Bounding box expansions with points and other boxes.
 inline bbox2f merge(const bbox2f& a, const vec2f& b) {
   return {min(a.min, b), max(a.max, b)};
 }
@@ -1399,11 +1399,11 @@ inline bbox2f merge(const bbox2f& a, const bbox2f& b) {
 inline void expand(bbox2f& a, const vec2f& b) { a = merge(a, b); }
 inline void expand(bbox2f& a, const bbox2f& b) { a = merge(a, b); }
 
-// Bounding box properties
+/// Bounding box properties
 inline vec3f center(const bbox3f& a) { return (a.min + a.max) / 2; }
 inline vec3f size(const bbox3f& a) { return a.max - a.min; }
 
-// Bounding box comparisons.
+/// Bounding box comparisons.
 inline bool operator==(const bbox3f& a, const bbox3f& b) {
   return a.min == b.min && a.max == b.max;
 }
@@ -1411,7 +1411,7 @@ inline bool operator!=(const bbox3f& a, const bbox3f& b) {
   return a.min != b.min || a.max != b.max;
 }
 
-// Bounding box expansions with points and other boxes.
+/// Bounding box expansions with points and other boxes.
 inline bbox3f merge(const bbox3f& a, const vec3f& b) {
   return {min(a.min, b), max(a.max, b)};
 }
@@ -1421,7 +1421,7 @@ inline bbox3f merge(const bbox3f& a, const bbox3f& b) {
 inline void expand(bbox3f& a, const vec3f& b) { a = merge(a, b); }
 inline void expand(bbox3f& a, const bbox3f& b) { a = merge(a, b); }
 
-// Primitive bounds.
+/// Primitive bounds.
 inline bbox3f point_bounds(const vec3f& p) { return {p, p}; }
 inline bbox3f point_bounds(const vec3f& p, float r) {
   return {min(p - r, p + r), max(p - r, p + r)};
@@ -1449,7 +1449,7 @@ inline bbox3f quad_bounds(
 // -----------------------------------------------------------------------------
 namespace yocto {
 
-// Ray esplison
+/// Ray esplison
 inline const auto ray_eps = 1e-4f;
 
 struct ray2f {
@@ -1464,7 +1464,7 @@ struct ray2f {
       : o{o}, d{d}, tmin{tmin}, tmax{tmax} {}
 };
 
-// Rays with origin, direction and min/max t value.
+/// Rays with origin, direction and min/max t value.
 struct ray3f {
   vec3f o    = {0, 0, 0};
   vec3f d    = {0, 0, 1};
@@ -1484,7 +1484,7 @@ struct ray3f {
 // -----------------------------------------------------------------------------
 namespace yocto {
 
-// Transforms points, vectors and directions by matrices.
+/// Transforms points, vectors and directions by matrices.
 inline vec2f transform_point(const mat3f& a, const vec2f& b) {
   auto tvb = a * vec3f{b.x, b.y, 1};
   return vec2f{tvb.x, tvb.y} / tvb.z;
@@ -1526,7 +1526,7 @@ inline vec3f transform_normal(const mat3f& a, const vec3f& b) {
   return normalize(transform_vector(transpose(inverse(a)), b));
 }
 
-// Transforms points, vectors and directions by frames.
+/// Transforms points, vectors and directions by frames.
 inline vec2f transform_point(const frame2f& a, const vec2f& b) {
   return a.x * b.x + a.y * b.y + a.o;
 }
@@ -1545,7 +1545,7 @@ inline vec2f transform_normal(
   }
 }
 
-// Transforms points, vectors and directions by frames.
+/// Transforms points, vectors and directions by frames.
 inline vec3f transform_point(const frame3f& a, const vec3f& b) {
   return a.x * b.x + a.y * b.y + a.z * b.z + a.o;
 }
@@ -1564,7 +1564,7 @@ inline vec3f transform_normal(
   }
 }
 
-// Transforms rays and bounding boxes by matrices.
+/// Transforms rays and bounding boxes by matrices.
 inline ray3f transform_ray(const mat4f& a, const ray3f& b) {
   return {transform_point(a, b.o), transform_vector(a, b.d), b.tmin, b.tmax};
 }
@@ -1594,7 +1594,7 @@ inline bbox3f transform_bbox(const frame3f& a, const bbox3f& b) {
   return xformed;
 }
 
-// Translation, scaling and rotations transforms.
+/// Translation, scaling and rotations transforms.
 inline frame3f translation_frame(const vec3f& a) {
   return {{1, 0, 0}, {0, 1, 0}, {0, 0, 1}, a};
 }
@@ -1638,7 +1638,7 @@ inline frame3f rotation_frame(const mat3f& rot) {
   return {rot.x, rot.y, rot.z, {0, 0, 0}};
 }
 
-// Lookat frame. Z-axis can be inverted with inv_xz.
+/// Lookat frame. Z-axis can be inverted with inv_xz.
 inline frame3f lookat_frame(const vec3f& eye, const vec3f& center,
     const vec3f& up, bool inv_xz = false) {
   auto w = normalize(eye - center);
@@ -1651,7 +1651,7 @@ inline frame3f lookat_frame(const vec3f& eye, const vec3f& center,
   return {u, v, w, eye};
 }
 
-// OpenGL frustum, ortho and perspecgive matrices.
+/// OpenGL frustum, ortho and perspecgive matrices.
 inline mat4f frustum_mat(float l, float r, float b, float t, float n, float f) {
   return {{2 * n / (r - l), 0, 0, 0}, {0, 2 * n / (t - b), 0, 0},
       {(r + l) / (r - l), (t + b) / (t - b), -(f + n) / (f - n), -1},
@@ -1681,7 +1681,7 @@ inline mat4f perspective_mat(float fovy, float aspect, float near) {
       {0, 0, 2 * near, 0}};
 }
 
-// Rotation conversions.
+/// Rotation conversions.
 inline pair<vec3f, float> rotation_axisangle(const vec4f& quat) {
   return {normalize(vec3f{quat.x, quat.y, quat.z}), 2 * acos(quat.w)};
 }
@@ -1696,8 +1696,8 @@ inline vec4f rotation_quat(const vec4f& axisangle) {
       vec3f{axisangle.x, axisangle.y, axisangle.z}, axisangle.w);
 }
 
-// Computes the image uv coordinates corresponding to the view parameters.
-// Returns negative coordinates if out of the image.
+/// Computes the image uv coordinates corresponding to the view parameters.
+/// Returns negative coordinates if out of the image.
 inline vec2i get_image_coords(const vec2f& mouse_pos, const vec2f& center,
     float scale, const vec2i& txt_size) {
   auto xyf = (mouse_pos - center) / scale;
@@ -1705,7 +1705,7 @@ inline vec2i get_image_coords(const vec2f& mouse_pos, const vec2f& center,
       (int)round(xyf.y + txt_size.y / 2.0f)};
 }
 
-// Center image and autofit.
+/// Center image and autofit.
 inline void update_imview(vec2f& center, float& scale, const vec2i& imsize,
     const vec2i& winsize, bool zoom_to_fit) {
   if (zoom_to_fit) {
@@ -1717,7 +1717,7 @@ inline void update_imview(vec2f& center, float& scale, const vec2i& imsize,
   }
 }
 
-// Turntable for UI navigation.
+/// Turntable for UI navigation.
 inline void update_turntable(vec3f& from, vec3f& to, vec3f& up,
     const vec2f& rotate, float dolly, const vec2f& pan) {
   // rotate if necessary
@@ -1752,7 +1752,7 @@ inline void update_turntable(vec3f& from, vec3f& to, vec3f& up,
   }
 }
 
-// Turntable for UI navigation.
+/// Turntable for UI navigation.
 inline void update_turntable(frame3f& frame, float& focus, const vec2f& rotate,
     float dolly, const vec2f& pan) {
   // rotate if necessary
@@ -1781,7 +1781,7 @@ inline void update_turntable(frame3f& frame, float& focus, const vec2f& rotate,
   }
 }
 
-// FPS camera for UI navigation for a frame parametrization.
+/// FPS camera for UI navigation for a frame parametrization.
 inline void update_fpscam(
     frame3f& frame, const vec3f& transl, const vec2f& rotate) {
   // https://gamedev.stackexchange.com/questions/30644/how-to-keep-my-quaternion-using-fps-camera-from-tilting-and-messing-up
@@ -1804,14 +1804,14 @@ inline void update_fpscam(
 // -----------------------------------------------------------------------------
 namespace yocto {
 
-// print information and returns a timer that will print the time when
-// destroyed. Use with RIIA for scoped timing.
+/// print information and returns a timer that will print the time when
+/// destroyed. Use with RIIA for scoped timing.
 struct timer {
   timer() : start{get_time()} {}
   int64_t elapsed() { return get_time() - start; }
   string  elapsedf() {
     auto duration = get_time() - start;
-    auto elapsed  = duration / 1000000;  // milliseconds
+    auto elapsed  = duration / 1000000;  /// milliseconds
     auto hours    = (int)(elapsed / 3600000);
     elapsed %= 3600000;
     auto mins = (int)(elapsed / 60000);

--- a/yocto/yocto_obj.h
+++ b/yocto/yocto_obj.h
@@ -1,20 +1,20 @@
-//
-// # Yocto/OBJ: Tiny library for OBJ parsing
-//
-// Yocto/OBJ is a simple Wavefront OBJ parser that works with callbacks.
-// We make no attempt to provide a simple interface for OBJ but just the
-// low level parsing code. We support a few extensions such as camera and
-// environment map loading.
-//
-// Error reporting is done through exceptions using the `io_error` exception.
-//
-// ## Parse an OBJ file
-//
-// 1. define callbacks in `obj_callback` structure using lambda with capture
-//    if desired
-// 2. run the parse with `load_obj()`
-//
-//
+///
+/// # Yocto/OBJ: Tiny library for OBJ parsing
+///
+/// Yocto/OBJ is a simple Wavefront OBJ parser that works with callbacks.
+/// We make no attempt to provide a simple interface for OBJ but just the
+/// low level parsing code. We support a few extensions such as camera and
+/// environment map loading.
+///
+/// Error reporting is done through exceptions using the `io_error` exception.
+///
+/// ## Parse an OBJ file
+///
+/// 1. define callbacks in `obj_callback` structure using lambda with capture
+///    if desired
+/// 2. run the parse with `load_obj()`
+///
+///
 
 //
 // LICENSE:
@@ -54,7 +54,7 @@
 // -----------------------------------------------------------------------------
 namespace yocto {
 
-// OBJ vertex
+/// OBJ vertex
 struct obj_vertex {
   int position = 0;
   int texcoord = 0;
@@ -66,13 +66,13 @@ inline bool operator==(const obj_vertex& a, const obj_vertex& b) {
          a.normal == b.normal;
 }
 
-// Obj texture information.
+/// Obj texture information.
 struct obj_texture_info {
-  string path  = "";     // file path
-  bool   clamp = false;  // clamp to edge
-  float  scale = 1;      // scale for bump/displacement
+  string path  = "";     /// file path
+  bool   clamp = false;  /// clamp to edge
+  float  scale = 1;      /// scale for bump/displacement
 
-  // Properties not explicitly handled.
+  /// Properties not explicitly handled.
   unordered_map<string, vector<float>> props;
 
   obj_texture_info() {}
@@ -80,93 +80,93 @@ struct obj_texture_info {
   obj_texture_info(const string& path) : path{path} {}
 };
 
-// Obj material.
+/// Obj material.
 struct obj_material {
-  string name  = "";  // name
-  int    illum = 0;   // MTL illum mode
+  string name  = "";  /// name
+  int    illum = 0;   /// MTL illum mode
 
-  // base values
-  vec3f ke  = {0, 0, 0};  // emission color
-  vec3f ka  = {0, 0, 0};  // ambient color
-  vec3f kd  = {0, 0, 0};  // diffuse color
-  vec3f ks  = {0, 0, 0};  // specular color
-  vec3f kr  = {0, 0, 0};  // reflection color
-  vec3f kt  = {0, 0, 0};  // transmission color
-  float ns  = 0;          // Phong exponent color
-  float ior = 1;          // index of refraction
-  float op  = 1;          // opacity
+  /// base values
+  vec3f ke  = {0, 0, 0};  /// emission color
+  vec3f ka  = {0, 0, 0};  /// ambient color
+  vec3f kd  = {0, 0, 0};  /// diffuse color
+  vec3f ks  = {0, 0, 0};  /// specular color
+  vec3f kr  = {0, 0, 0};  /// reflection color
+  vec3f kt  = {0, 0, 0};  /// transmission color
+  float ns  = 0;          /// Phong exponent color
+  float ior = 1;          /// index of refraction
+  float op  = 1;          /// opacity
 
-  // textures
-  obj_texture_info ke_map   = "";  // emission texture
-  obj_texture_info ka_map   = "";  // ambient texture
-  obj_texture_info kd_map   = "";  // diffuse texture
-  obj_texture_info ks_map   = "";  // specular texture
-  obj_texture_info kr_map   = "";  // reflection texture
-  obj_texture_info kt_map   = "";  // transmission texture
-  obj_texture_info ns_map   = "";  // Phong exponent texture
-  obj_texture_info op_map   = "";  // opacity texture
-  obj_texture_info ior_map  = "";  // ior texture
-  obj_texture_info bump_map = "";  // bump map
+  /// textures
+  obj_texture_info ke_map   = "";  /// emission texture
+  obj_texture_info ka_map   = "";  /// ambient texture
+  obj_texture_info kd_map   = "";  /// diffuse texture
+  obj_texture_info ks_map   = "";  /// specular texture
+  obj_texture_info kr_map   = "";  /// reflection texture
+  obj_texture_info kt_map   = "";  /// transmission texture
+  obj_texture_info ns_map   = "";  /// Phong exponent texture
+  obj_texture_info op_map   = "";  /// opacity texture
+  obj_texture_info ior_map  = "";  /// ior texture
+  obj_texture_info bump_map = "";  /// bump map
 
-  // pbr values
-  bool  has_pbr = false;  // whether pbr values are defined
-  float pr      = 0;      // roughness
-  float pm      = 0;      // metallic
-  float ps      = 0;      // sheen
-  float pc      = 0;      // coat
-  float pcr     = 0;      // coat roughness
+  /// pbr values
+  bool  has_pbr = false;  /// whether pbr values are defined
+  float pr      = 0;      /// roughness
+  float pm      = 0;      /// metallic
+  float ps      = 0;      /// sheen
+  float pc      = 0;      /// coat
+  float pcr     = 0;      /// coat roughness
 
-  // textures
-  obj_texture_info pr_map   = "";  // roughness texture
-  obj_texture_info pm_map   = "";  // metallic texture
-  obj_texture_info ps_map   = "";  // sheen texture
-  obj_texture_info norm_map = "";  // normal map
-  obj_texture_info disp_map = "";  // displacement map
-  obj_texture_info occ_map  = "";  // occlusion map
+  /// textures
+  obj_texture_info pr_map   = "";  /// roughness texture
+  obj_texture_info pm_map   = "";  /// metallic texture
+  obj_texture_info ps_map   = "";  /// sheen texture
+  obj_texture_info norm_map = "";  /// normal map
+  obj_texture_info disp_map = "";  /// displacement map
+  obj_texture_info occ_map  = "";  /// occlusion map
 
-  // Properties not explicitly handled.
+  /// Properties not explicitly handled.
   unordered_map<string, vector<string>> props;
 };
 
-// Obj camera [extension].
+/// Obj camera [extension].
 struct obj_camera {
-  string  name     = "";            // name
-  frame3f frame    = identity3x4f;  // transform
-  bool    ortho    = false;         // orthographic
-  float   width    = 0.036f;        // film size (default to 35mm)
-  float   height   = 0.024f;        // film size (default to 35mm)
-  float   lens     = 0.050f;        // focal length
-  float   aperture = 0;             // lens aperture
-  float   focus    = flt_max;       // focus distance
+  string  name     = "";            /// name
+  frame3f frame    = identity3x4f;  /// transform
+  bool    ortho    = false;         /// orthographic
+  float   width    = 0.036f;        /// film size (default to 35mm)
+  float   height   = 0.024f;        /// film size (default to 35mm)
+  float   lens     = 0.050f;        /// focal length
+  float   aperture = 0;             /// lens aperture
+  float   focus    = flt_max;       /// focus distance
 };
 
-// Obj environment [extension].
+/// Obj environment [extension].
 struct obj_environment {
-  string           name  = "";            // name
-  frame3f          frame = identity3x4f;  // transform
-  vec3f            ke    = zero3f;        // emission color
-  obj_texture_info ke_txt;                // emission texture
+  string           name  = "";            /// name
+  frame3f          frame = identity3x4f;  /// transform
+  vec3f            ke    = zero3f;        /// emission color
+  obj_texture_info ke_txt;                /// emission texture
 };
 
-// Obj procedural object [extension].
+/// Obj procedural object [extension].
 struct obj_procedural {
-  string  name     = "";            // name
-  frame3f frame    = identity3x4f;  // transform
-  string  type     = "";            // type
-  string  material = "";            // material
-  float   size     = 2;             // size
-  int     level    = -1;            // level of subdivision (-1 default)
+  string  name     = "";            /// name
+  frame3f frame    = identity3x4f;  /// transform
+  string  type     = "";            /// type
+  string  material = "";            /// material
+  float   size     = 2;             /// size
+  int     level    = -1;            /// level of subdivision (-1 default)
 };
 
-// Obj instance [extension]
+/// Obj instance [extension]
 struct obj_instance {
-  string  name     = "";            // name
-  frame3f frame    = identity3x4f;  // transform
-  string  object   = "";            // object name
-  string  material = "";            // material name
+  string  name     = "";            /// name
+  frame3f frame    = identity3x4f;  /// transform
+  string  object   = "";            /// object name
+  string  material = "";            /// material name
 };
 
-// Obj callbacks
+/// Obj callbacks
 struct obj_callbacks {
   virtual void vert(const vec3f&) {}
   virtual void norm(const vec3f&) {}
@@ -186,7 +186,7 @@ struct obj_callbacks {
   virtual void procedural(const obj_procedural&) {}
 };
 
-// Load obj scene
+/// Load obj scene
 void load_obj(const string& filename, obj_callbacks& cb,
     bool nomaterials = false, bool flipv = true, bool fliptr = true);
 
@@ -197,7 +197,7 @@ void load_obj(const string& filename, obj_callbacks& cb,
 // -----------------------------------------------------------------------------
 namespace std {
 
-// Hash functor for vector for use with unordered_map
+/// Hash functor for vector for use with unordered_map
 template <>
 struct hash<yocto::obj_vertex> {
   size_t operator()(const yocto::obj_vertex& v) const {

--- a/yocto/yocto_pbrt.h
+++ b/yocto/yocto_pbrt.h
@@ -1,20 +1,20 @@
-//
-// # Yocto/Pbrt: Tiny library for Pbrt parsing
-//
-// Yocto/Pbrt is a simple pbrt parser that works with callbacks.
-// We make no attempt to provide a simple interface for pbrt but just the
-// low level parsing code.
-//
-// Error reporting is done through exceptions using the `io_error`
-// exception.
-//
-// ## Parse an pbrt file
-//
-// 1. define callbacks in `pbrt_callback` structure using lambda with capture
-//    if desired
-// 2. run the parse with `load_pbrt()`
-//
-//
+///
+/// # Yocto/Pbrt: Tiny library for Pbrt parsing
+///
+/// Yocto/Pbrt is a simple pbrt parser that works with callbacks.
+/// We make no attempt to provide a simple interface for pbrt but just the
+/// low level parsing code.
+///
+/// Error reporting is done through exceptions using the `io_error`
+/// exception.
+///
+/// ## Parse an pbrt file
+///
+/// 1. define callbacks in `pbrt_callback` structure using lambda with capture
+///    if desired
+/// 2. run the parse with `load_pbrt()`
+///
+///
 
 //
 // LICENSE:
@@ -54,7 +54,7 @@
 // -----------------------------------------------------------------------------
 namespace yocto {
 
-// pbrt pbrt_spectrum as rgb color
+/// pbrt pbrt_spectrum as rgb color
 struct pbrt_spectrum3f {
   float x = 0;
   float y = 0;
@@ -69,11 +69,11 @@ struct pbrt_spectrum3f {
   const float& operator[](int i) const { return (&x)[i]; }
 };
 
-// pbrt cameras
+/// pbrt cameras
 struct pbrt_camera {
   struct perspective_t {
     float fov              = 90;
-    float frameaspectratio = -1;  // or computed from film
+    float frameaspectratio = -1;  /// or computed from film
     float lensradius       = 0;
     float focaldistance    = 1e30;
     vec4f screenwindow     = {-1, 1, -1, 1};
@@ -81,7 +81,7 @@ struct pbrt_camera {
     float shutterclose     = 1;
   };
   struct orthographic_t {
-    float frameaspectratio = -1;  // or computed from film
+    float frameaspectratio = -1;  /// or computed from film
     float lensradius       = 0;
     float focaldistance    = 1e30;
     vec4f screenwindow     = {-1, 1, -1, 1};
@@ -109,7 +109,7 @@ struct pbrt_camera {
   realistic_t    realistic    = {};
 };
 
-// pbrt samplers
+/// pbrt samplers
 struct pbrt_sampler {
   struct random_t {
     int pixelsamples = 16;
@@ -148,7 +148,7 @@ struct pbrt_sampler {
   stratified_t      stratified      = {};
 };
 
-// pbrt film
+/// pbrt film
 struct pbrt_film {
   struct image_t {
     int    xresolution        = 640;
@@ -164,7 +164,7 @@ struct pbrt_film {
   image_t image = {};
 };
 
-// pbrt filters
+/// pbrt filters
 struct pbrt_filter {
   struct box_t {
     float xwidth = 0.5;
@@ -199,7 +199,7 @@ struct pbrt_filter {
   triangle_t triangle = {};
 };
 
-// pbrt integrators
+/// pbrt integrators
 struct pbrt_integrator {
   struct path_t {
     enum struct lightsamplestrategy_t { uniform, power, spatial };
@@ -269,7 +269,7 @@ struct pbrt_integrator {
   whitted_t        whitted        = {};
 };
 
-// pbrt accellerators
+/// pbrt accellerators
 struct pbrt_accelerator {
   struct bvh_t {
     enum struct splitmethod_t { sah, equal, middle, hlbvh };
@@ -289,7 +289,7 @@ struct pbrt_accelerator {
   kdtree_t kdtree = {};
 };
 
-// pbrt texture or value
+/// pbrt texture or value
 struct pbrt_textured1f {
   float  value   = 0;
   string texture = "";
@@ -303,7 +303,7 @@ struct pbrt_textured3f {
   pbrt_textured3f(float x, float y, float z) : value{x, y, z}, texture{} {}
 };
 
-// pbrt textures
+/// pbrt textures
 struct pbrt_texture {
   struct constant_t {
     pbrt_textured3f value = {1, 1, 1};
@@ -431,7 +431,7 @@ struct pbrt_texture {
   wrinkled_t     wrinkled     = {};
 };
 
-// pbrt materials
+/// pbrt materials
 struct pbrt_material {
   struct matte_t {
     pbrt_textured3f Kd      = {0.5, 0.5, 0.5};
@@ -519,10 +519,10 @@ struct pbrt_material {
     glass_t       approx_glass   = {};
   };
   struct hair_t {
-    pbrt_textured3f color       = {0, 0, 0};  // TODO: missing default
-    pbrt_textured3f sigma_a     = {0, 0, 0};  // TODO: missing default
-    pbrt_textured1f eumelanin   = 0;          // TODO: missing default
-    pbrt_textured1f pheomelanin = 0;          // TODO: missing default
+    pbrt_textured3f color       = {0, 0, 0};  /// TODO: missing default
+    pbrt_textured3f sigma_a     = {0, 0, 0};  /// TODO: missing default
+    pbrt_textured1f eumelanin   = 0;          /// TODO: missing default
+    pbrt_textured1f pheomelanin = 0;          /// TODO: missing default
     pbrt_textured1f eta         = 1.55f;
     pbrt_textured1f beta_m      = 0.3f;
     pbrt_textured1f beta_n      = 0.3f;
@@ -600,7 +600,7 @@ struct pbrt_material {
   subsurface_t   subsurface{};
 };
 
-// pbrt shapes
+/// pbrt shapes
 struct pbrt_shape {
   struct trianglemesh_t {
     vector<vec3i>   indices     = {};
@@ -713,7 +713,7 @@ struct pbrt_shape {
   heightfield_t  heightfield  = {};
 };
 
-// pbrt lights
+/// pbrt lights
 struct pbrt_light {
   struct distant_t {
     pbrt_spectrum3f scale = {1, 1, 1};
@@ -768,7 +768,7 @@ struct pbrt_light {
   spot_t        spot        = {};
 };
 
-// pbrt area lights
+/// pbrt area lights
 struct pbrt_arealight {
   struct none_t {};
   struct diffuse_t {
@@ -783,7 +783,7 @@ struct pbrt_arealight {
   diffuse_t diffuse = {};
 };
 
-// pbrt mediums
+/// pbrt mediums
 struct pbrt_medium {
   struct homogeneous_t {
     pbrt_spectrum3f sigma_a = {0.0011, 0.0024, 0.014};
@@ -811,18 +811,18 @@ struct pbrt_medium {
   heterogeneous_t heterogeneous = {};
 };
 
-// pbrt medium interface
+/// pbrt medium interface
 struct pbrt_mediuminterface {
   string interior = "";
   string exterior = "";
 };
 
-// pbrt insstance
+/// pbrt insstance
 struct pbrt_object {
   string name = "";
 };
 
-// pbrt stack ctm
+/// pbrt stack ctm
 struct pbrt_context {
   frame3f transform_start        = identity3x4f;
   frame3f transform_end          = identity3x4f;
@@ -836,7 +836,7 @@ struct pbrt_context {
   float   last_lookat_distance   = 0;
 };
 
-// pbrt callbacks
+/// pbrt callbacks
 struct pbrt_callbacks {
   virtual void sampler(const pbrt_sampler& value, const pbrt_context& ctx) {}
   virtual void integrator(
@@ -863,7 +863,7 @@ struct pbrt_callbacks {
   virtual void end_object(const pbrt_object& value, const pbrt_context& ctx) {}
 };
 
-// Load pbrt scene
+/// Load pbrt scene
 void load_pbrt(const string& filename, pbrt_callbacks& cb, bool flipv = true);
 
 }  // namespace yocto

--- a/yocto/yocto_random.h
+++ b/yocto/yocto_random.h
@@ -1,37 +1,37 @@
-//
-// # Yocto/Random: Tiny library for random number generatio and Monte Carlo.
-//
-// Yocto/Random provides utilities for random number generation, hasing,
-// Monte Carlo integration and sampling and Perloin noise.
-//
-//
-// ## Random Number Generation, Noise, and Monte Carlo support
-//
-// This library supports many facilities helpful in writing sampling
-// functions targeting path tracing and shape generations. Implementation of
-// Perlin noise is include based on stb libraries.
-//
-// 1. Random number generation with PCG32:
-//     1. initialize the random number generator with `make_rng()`
-//     2. advance the random number state with `advance_rng()`
-//     3. if necessary, you can reseed the rng with `seed_rng()`
-//     4. generate random integers in an interval with `rand1i()`
-//     5. generate random floats and double in the [0,1) range with
-//        `rand1f()`, `rand2f()`, `rand3f()`,
-//        `next_rand1d()`
-// 2. Perlin noise: `perlin_noise()` to generate Perlin noise with optional
-//    wrapping, with fractal variations `perlin_ridge()`,
-//    `perlin_fbm()`, `perlin_turbulence()`
-// 3. Monte Carlo support: warp functions from [0,1)^k domains to domains
-//    commonly used in path tracing. In particular, use
-//    `sample_hemisphere()`, `sample_sphere()`,
-//    `sample_hemisphere_cos()`,
-//    `sample_hemisphere_cospower()`. `sample_disk()`.
-//    `sample_cylinder()`. `sample_triangle()`,
-//    `sample_discrete()`. For each warp, you can compute
-//     the PDF with `sample_xxx_pdf()`.
-//
-//
+///
+/// # Yocto/Random: Tiny library for random number generatio and Monte Carlo.
+///
+/// Yocto/Random provides utilities for random number generation, hasing,
+/// Monte Carlo integration and sampling and Perloin noise.
+///
+///
+/// ## Random Number Generation, Noise, and Monte Carlo support
+///
+/// This library supports many facilities helpful in writing sampling
+/// functions targeting path tracing and shape generations. Implementation of
+/// Perlin noise is include based on stb libraries.
+///
+/// 1. Random number generation with PCG32:
+///     1. initialize the random number generator with `make_rng()`
+///     2. advance the random number state with `advance_rng()`
+///     3. if necessary, you can reseed the rng with `seed_rng()`
+///     4. generate random integers in an interval with `rand1i()`
+///     5. generate random floats and double in the [0,1) range with
+///        `rand1f()`, `rand2f()`, `rand3f()`,
+///        `next_rand1d()`
+/// 2. Perlin noise: `perlin_noise()` to generate Perlin noise with optional
+///    wrapping, with fractal variations `perlin_ridge()`,
+///    `perlin_fbm()`, `perlin_turbulence()`
+/// 3. Monte Carlo support: warp functions from [0,1)^k domains to domains
+///    commonly used in path tracing. In particular, use
+///    `sample_hemisphere()`, `sample_sphere()`,
+///    `sample_hemisphere_cos()`,
+///    `sample_hemisphere_cospower()`. `sample_disk()`.
+///    `sample_cylinder()`. `sample_triangle()`,
+///    `sample_discrete()`. For each warp, you can compute
+///     the PDF with `sample_xxx_pdf()`.
+///
+///
 
 //
 // LICENSE:
@@ -106,7 +106,7 @@
 // -----------------------------------------------------------------------------
 namespace yocto {
 
-// PCG random numbers from http://www.pcg-random.org/
+/// PCG random numbers from http://www.pcg-random.org/
 struct rng_state {
   uint64_t state = 0x853c49e6748fea9bULL;
   uint64_t inc   = 0xda3e39cb94b95bdbULL;
@@ -115,7 +115,7 @@ struct rng_state {
   rng_state(uint64_t state, uint64_t inc) : state{state}, inc{inc} {}
 };
 
-// Next random number, used internally only.
+/// Next random number, used internally only.
 inline uint32_t _advance_rng(rng_state& rng) {
   uint64_t oldstate   = rng.state;
   rng.state           = oldstate * 6364136223846793005ULL + rng.inc;
@@ -124,7 +124,7 @@ inline uint32_t _advance_rng(rng_state& rng) {
   return (xorshifted >> rot) | (xorshifted << ((-rot) & 31));
 }
 
-// Init a random number generator with a state state from the sequence seq.
+/// Init a random number generator with a state state from the sequence seq.
 inline rng_state make_rng(uint64_t seed, uint64_t seq = 1) {
   auto rng  = rng_state();
   rng.state = 0U;
@@ -135,7 +135,7 @@ inline rng_state make_rng(uint64_t seed, uint64_t seq = 1) {
   return rng;
 }
 
-// Next random numbers: floats in [0,1), ints in [0,n).
+/// Next random numbers: floats in [0,1), ints in [0,n).
 inline int   rand1i(rng_state& rng, int n) { return _advance_rng(rng) % n; }
 inline float rand1f(rng_state& rng) {
   union {
@@ -162,7 +162,7 @@ inline vec3f rand3f(rng_state& rng) {
   return {x, y, z};
 }
 
-// Shuffles a sequence of elements
+/// Shuffles a sequence of elements
 template <typename T>
 inline void shuffle(vector<T>& vals, rng_state& rng) {
   // https://en.wikipedia.org/wiki/Fisher–Yates_shuffle
@@ -179,7 +179,7 @@ inline void shuffle(vector<T>& vals, rng_state& rng) {
 // -----------------------------------------------------------------------------
 namespace yocto {
 
-// Sample an hemispherical direction with uniform distribution.
+/// Sample an hemispherical direction with uniform distribution.
 inline vec3f sample_hemisphere(const vec2f& ruv) {
   auto z   = ruv.y;
   auto r   = sqrt(clamp(1 - z * z, 0.0f, 1.0f));
@@ -190,7 +190,7 @@ inline float sample_hemisphere_pdf(const vec3f& direction) {
   return (direction.z <= 0) ? 0 : 1 / (2 * pif);
 }
 
-// Sample an hemispherical direction with uniform distribution.
+/// Sample an hemispherical direction with uniform distribution.
 inline vec3f sample_hemisphere(const vec3f& normal, const vec2f& ruv) {
   auto z               = ruv.y;
   auto r               = sqrt(clamp(1 - z * z, 0.0f, 1.0f));
@@ -203,7 +203,7 @@ inline float sample_hemisphere_pdf(
   return (dot(normal, direction) <= 0) ? 0 : 1 / (2 * pif);
 }
 
-// Sample a spherical direction with uniform distribution.
+/// Sample a spherical direction with uniform distribution.
 inline vec3f sample_sphere(const vec2f& ruv) {
   auto z   = 2 * ruv.y - 1;
   auto r   = sqrt(clamp(1 - z * z, 0.0f, 1.0f));
@@ -212,7 +212,7 @@ inline vec3f sample_sphere(const vec2f& ruv) {
 }
 inline float sample_sphere_pdf(const vec3f& w) { return 1 / (4 * pif); }
 
-// Sample an hemispherical direction with cosine distribution.
+/// Sample an hemispherical direction with cosine distribution.
 inline vec3f sample_hemisphere_cos(const vec2f& ruv) {
   auto z   = sqrt(ruv.y);
   auto r   = sqrt(1 - z * z);
@@ -223,7 +223,7 @@ inline float sample_hemisphere_cos_pdf(const vec3f& direction) {
   return (direction.z <= 0) ? 0 : direction.z / pif;
 }
 
-// Sample an hemispherical direction with cosine power distribution.
+/// Sample an hemispherical direction with cosine power distribution.
 inline vec3f sample_hemisphere_cospower(float exponent, const vec2f& ruv) {
   auto z   = pow(ruv.y, 1 / (exponent + 1));
   auto r   = sqrt(1 - z * z);
@@ -237,7 +237,7 @@ inline float sample_hemisphere_cospower_pdf(
              : pow(direction.z, exponent) * (exponent + 1) / (2 * pif);
 }
 
-// Sample a point uniformly on a disk.
+/// Sample a point uniformly on a disk.
 inline vec2f sample_disk(const vec2f& ruv) {
   auto r   = sqrt(ruv.y);
   auto phi = 2 * pif * ruv.x;
@@ -245,37 +245,37 @@ inline vec2f sample_disk(const vec2f& ruv) {
 }
 inline float sample_disk_pdf() { return 1 / pif; }
 
-// Sample a point uniformly on a cylinder, without caps.
+/// Sample a point uniformly on a cylinder, without caps.
 inline vec3f sample_cylinder(const vec2f& ruv) {
   auto phi = 2 * pif * ruv.x;
   return {sin(phi), cos(phi), ruv.y * 2 - 1};
 }
 inline float sample_cylinder_pdf() { return 1 / pif; }
 
-// Sample a point uniformly on a triangle returning the baricentric coordinates.
+/// Sample a point uniformly on a triangle returning the baricentric coordinates.
 inline vec2f sample_triangle(const vec2f& ruv) {
   return {1 - sqrt(ruv.x), ruv.y * sqrt(ruv.x)};
 }
 
-// Sample a point uniformly on a triangle.
+/// Sample a point uniformly on a triangle.
 inline vec3f sample_triangle(
     const vec3f& p0, const vec3f& p1, const vec3f& p2, const vec2f& ruv) {
   auto uv = sample_triangle(ruv);
   return p0 * (1 - uv.x - uv.y) + p1 * uv.x + p2 * uv.y;
 }
-// Pdf for uniform triangle sampling, i.e. triangle area.
+/// Pdf for uniform triangle sampling, i.e. triangle area.
 inline float sample_triangle_pdf(
     const vec3f& p0, const vec3f& p1, const vec3f& p2) {
   return 2 / length(cross(p1 - p0, p2 - p0));
 }
 
-// Sample an index with uniform distribution.
+/// Sample an index with uniform distribution.
 inline int sample_uniform(int size, float r) {
   return clamp((int)(r * size), 0, size - 1);
 }
 inline float sample_uniform_pdf(int size) { return (float)1 / (float)size; }
 
-// Sample an index with uniform distribution.
+/// Sample an index with uniform distribution.
 inline float sample_uniform(const vector<float>& elements, float r) {
   if (elements.empty()) return {};
   auto size = (int)elements.size();
@@ -286,14 +286,14 @@ inline float sample_uniform_pdf(const vector<float>& elements) {
   return 1.0f / (int)elements.size();
 }
 
-// Sample a discrete distribution represented by its cdf.
+/// Sample a discrete distribution represented by its cdf.
 inline int sample_discrete(const vector<float>& cdf, float r) {
   r        = clamp(r * cdf.back(), (float)0, cdf.back() - (float)0.00001);
   auto idx = (int)(std::upper_bound(cdf.data(), cdf.data() + cdf.size(), r) -
                    cdf.data());
   return clamp(idx, 0, (int)cdf.size() - 1);
 }
-// Pdf for uniform discrete distribution sampling.
+/// Pdf for uniform discrete distribution sampling.
 inline float sample_discrete_pdf(const vector<float>& cdf, int idx) {
   if (idx == 0) return cdf.at(0);
   return cdf.at(idx) - cdf.at(idx - 1);
@@ -306,12 +306,12 @@ inline float sample_discrete_pdf(const vector<float>& cdf, int idx) {
 // -----------------------------------------------------------------------------
 namespace yocto {
 
-// Compute the revised Perlin noise function. Wrap provides a wrapping noise
-// but must be power of two (wraps at 256 anyway). For octave based noise,
-// good values are obtained with octaves=6 (numerber of noise calls),
-// lacunarity=~2.0 (spacing between successive octaves: 2.0 for warpping
-// output), gain=0.5 (relative weighting applied to each successive octave),
-// offset=1.0 (used to invert the ridges).
+/// Compute the revised Perlin noise function. Wrap provides a wrapping noise
+/// but must be power of two (wraps at 256 anyway). For octave based noise,
+/// good values are obtained with octaves=6 (numerber of noise calls),
+/// lacunarity=~2.0 (spacing between successive octaves: 2.0 for warpping
+/// output), gain=0.5 (relative weighting applied to each successive octave),
+/// offset=1.0 (used to invert the ridges).
 inline float perlin_noise(const vec3f& p, const vec3i& wrap = zero3i);
 inline float perlin_ridge(const vec3f& p, float lacunarity = 2,
     float gain = 0.5, int octaves = 6, float offset = 1,
@@ -328,7 +328,7 @@ inline float perlin_turbulence(const vec3f& p, float lacunarity = 2,
 // -----------------------------------------------------------------------------
 namespace yocto {
 
-// clang-format off
+/// clang-format off
 inline float _stb__perlin_lerp(float a, float b, float t)
 {
    return a + (b-a) * t;
@@ -340,7 +340,7 @@ inline int _stb__perlin_fastfloor(float a)
     return (a < ai) ? ai-1 : ai;
 }
 
-// different grad function from Perlin's, but easy to modify to match reference
+/// different grad function from Perlin's, but easy to modify to match reference
 inline float _stb__perlin_grad(int hash, float x, float y, float z)
 {
    static float basis[12][4] =
@@ -359,9 +359,9 @@ inline float _stb__perlin_grad(int hash, float x, float y, float z)
       {  0,-1,-1 },
    };
 
-   // perlin's gradient has 12 cases so some get used 1/16th of the time
-   // and some 2/16ths. We reduce bias by changing those fractions
-   // to 5/64ths and 6/64ths, and the same 4 cases get the extra weight.
+   /// perlin's gradient has 12 cases so some get used 1/16th of the time
+   /// and some 2/16ths. We reduce bias by changing those fractions
+   /// to 5/64ths and 6/64ths, and the same 4 cases get the extra weight.
    static unsigned char indices[64] =
    {
       0,1,2,3,4,5,6,7,8,9,10,11,
@@ -372,17 +372,17 @@ inline float _stb__perlin_grad(int hash, float x, float y, float z)
       0,1,2,3,4,5,6,7,8,9,10,11,
    };
 
-   // if you use reference permutation table, change 63 below to 15 to match reference
-   // (this is why the ordering of the table above is funky)
+   /// if you use reference permutation table, change 63 below to 15 to match reference
+   /// (this is why the ordering of the table above is funky)
    float *grad = basis[indices[hash & 63]];
    return grad[0]*x + grad[1]*y + grad[2]*z;
 }
 
 inline float _stb_perlin_noise3(float x, float y, float z, int x_wrap, int y_wrap, int z_wrap)
 {
-    // not same permutation table as Perlin's reference to avoid copyright issues;
-    // Perlin's table can be found at http://mrl.nyu.edu/~perlin/noise/
-    // @OPTIMIZE: should this be unsigned char instead of int for cache?
+    /// not same permutation table as Perlin's reference to avoid copyright issues;
+    /// Perlin's table can be found at http://mrl.nyu.edu/~perlin/noise/
+    /// @OPTIMIZE: should this be unsigned char instead of int for cache?
     static unsigned char _stb__perlin_randtab[512] =
     {
     23, 125, 161, 52, 103, 117, 70, 37, 247, 101, 203, 169, 124, 126, 44, 123,
@@ -525,26 +525,26 @@ inline float _stb_perlin_turbulence_noise3(float x, float y, float z, float lacu
 }
 // clang-format on
 
-// adapeted  stb_perlin.h
+/// adapeted  stb_perlin.h
 inline float perlin_noise(const vec3f& p, const vec3i& wrap) {
   return _stb_perlin_noise3(p.x, p.y, p.z, wrap.x, wrap.y, wrap.z);
 }
 
-// adapeted  stb_perlin.h
+/// adapeted  stb_perlin.h
 inline float perlin_ridge(const vec3f& p, float lacunarity, float gain,
     int octaves, float offset, const vec3i& wrap) {
   return _stb_perlin_ridge_noise3(
       p.x, p.y, p.z, lacunarity, gain, offset, octaves, wrap.x, wrap.y, wrap.z);
 }
 
-// adapeted  stb_perlin.h
+/// adapeted  stb_perlin.h
 inline float perlin_fbm(const vec3f& p, float lacunarity, float gain,
     int octaves, const vec3i& wrap) {
   return _stb_perlin_fbm_noise3(
       p.x, p.y, p.z, lacunarity, gain, octaves, wrap.x, wrap.y, wrap.z);
 }
 
-// adapeted  stb_perlin.h
+/// adapeted  stb_perlin.h
 inline float perlin_turbulence(const vec3f& p, float lacunarity, float gain,
     int octaves, const vec3i& wrap) {
   return _stb_perlin_turbulence_noise3(

--- a/yocto/yocto_scene.h
+++ b/yocto/yocto_scene.h
@@ -1,35 +1,35 @@
-//
-// # Yocto/Scene: Tiny library for scene representation
-//
-//
-// Yocto/Scene is a library to represent 3D scenes using a simple data-driven
-// and value oriented design.
-//
-//
-// ## Simple scene representation
-//
-// Yocto/Scene define a simple scene data structure useful to create quick demos
-// and as the repsetnation upon which the path tracer works.
-//
-// In Yocto scenes, shapes are represented as indexed collections of points,
-// lines, triangles, quads and bezier segments. Each shape may contain
-// only one element type. Shapes are organized into a scene by creating shape
-// instances, each its own transform. Materials are specified like in OBJ and
-// glTF and include emission, base-metallic and diffuse-specular
-// parametrization, normal, occlusion and displacement mapping. Finally, the
-// scene containers cameras and environment maps. Quad support in shapes is
-// experimental and mostly supported for loading and saving. Lights in
-// Yocto/Scene are pointers to either instances or environments. The scene
-// supports an optional node hierarchy with animation modeled on the glTF model.
-//
-// 1. load a scene with Yocto/SceneIO,
-// 2. use `compute_shape_box()/compute_scene_box()` to compute element bounds
-// 3. compute interpolated values over scene elements with `evaluate_XXX()`
-//    functions
-// 4. for ray-intersection and closest point queries, use
-//    'make_bvh()`/`refit_bvh()`
-//
-//
+///
+/// # Yocto/Scene: Tiny library for scene representation
+///
+///
+/// Yocto/Scene is a library to represent 3D scenes using a simple data-driven
+/// and value oriented design.
+///
+///
+/// ## Simple scene representation
+///
+/// Yocto/Scene define a simple scene data structure useful to create quick demos
+/// and as the repsetnation upon which the path tracer works.
+///
+/// In Yocto scenes, shapes are represented as indexed collections of points,
+/// lines, triangles, quads and bezier segments. Each shape may contain
+/// only one element type. Shapes are organized into a scene by creating shape
+/// instances, each its own transform. Materials are specified like in OBJ and
+/// glTF and include emission, base-metallic and diffuse-specular
+/// parametrization, normal, occlusion and displacement mapping. Finally, the
+/// scene containers cameras and environment maps. Quad support in shapes is
+/// experimental and mostly supported for loading and saving. Lights in
+/// Yocto/Scene are pointers to either instances or environments. The scene
+/// supports an optional node hierarchy with animation modeled on the glTF model.
+///
+/// 1. load a scene with Yocto/SceneIO,
+/// 2. use `compute_shape_box()/compute_scene_box()` to compute element bounds
+/// 3. compute interpolated values over scene elements with `evaluate_XXX()`
+///    functions
+/// 4. for ray-intersection and closest point queries, use
+///    'make_bvh()`/`refit_bvh()`
+///
+///
 
 //
 // LICENSE:
@@ -72,18 +72,18 @@
 // -----------------------------------------------------------------------------
 namespace yocto {
 
-// Camera based on a simple lens model. The camera is placed using a frame.
-// Camera projection is described in photorgaphics terms. In particular,
-// we specify fil size (35mm by default), the lens' focal length, the focus
-// distance and the lens aperture. All values are in meters.
-// Here are some common aspect ratios used in video and still photography.
-// 3:2    on 35 mm:  0.036 x 0.024
-// 16:9   on 35 mm:  0.036 x 0.02025 or 0.04267 x 0.024
-// 2.35:1 on 35 mm:  0.036 x 0.01532 or 0.05640 x 0.024
-// 2.39:1 on 35 mm:  0.036 x 0.01506 or 0.05736 x 0.024
-// 2.4:1  on 35 mm:  0.036 x 0.015   or 0.05760 x 0.024 (approx. 2.39 : 1)
-// To compute good apertures, one can use the F-stop number from phostography
-// and set the aperture to focal_leangth/f_stop.
+/// Camera based on a simple lens model. The camera is placed using a frame.
+/// Camera projection is described in photorgaphics terms. In particular,
+/// we specify fil size (35mm by default), the lens' focal length, the focus
+/// distance and the lens aperture. All values are in meters.
+/// Here are some common aspect ratios used in video and still photography.
+/// 3:2    on 35 mm:  0.036 x 0.024
+/// 16:9   on 35 mm:  0.036 x 0.02025 or 0.04267 x 0.024
+/// 2.35:1 on 35 mm:  0.036 x 0.01532 or 0.05640 x 0.024
+/// 2.39:1 on 35 mm:  0.036 x 0.01506 or 0.05736 x 0.024
+/// 2.4:1  on 35 mm:  0.036 x 0.015   or 0.05760 x 0.024 (approx. 2.39 : 1)
+/// To compute good apertures, one can use the F-stop number from phostography
+/// and set the aperture to focal_leangth/f_stop.
 struct yocto_camera {
   string  uri          = "";
   frame3f frame        = identity3x4f;
@@ -94,29 +94,29 @@ struct yocto_camera {
   float   aperture     = 0;
 };
 
-// Texture containing either an LDR or HDR image. Textures are rendered
-// using linear interpolation (unless `no_interoilation` is set) and
-// weith tiling (unless `clamp_to_edge` is set). HdR images are encoded
-// in linear color space, while LDRs are encoded as sRGB. The latter
-// conversion can be disabled with `ldr_as_linear` for example to render
-// normal maps.
+/// Texture containing either an LDR or HDR image. Textures are rendered
+/// using linear interpolation (unless `no_interoilation` is set) and
+/// weith tiling (unless `clamp_to_edge` is set). HdR images are encoded
+/// in linear color space, while LDRs are encoded as sRGB. The latter
+/// conversion can be disabled with `ldr_as_linear` for example to render
+/// normal maps.
 struct yocto_texture {
   string       uri = "";
   image<vec4f> hdr = {};
   image<vec4b> ldr = {};
 };
 
-// Volumetric texture containing a float only volume data. See texture
-// above for other propoerties.
+/// Volumetric texture containing a float only volume data. See texture
+/// above for other propoerties.
 struct yocto_voltexture {
   string        uri = "";
   volume<float> vol = {};
 };
 
-// Material for surfaces, lines and triangles.
-// For surfaces, uses a microfacet model with thin sheet transmission.
-// The model is based on OBJ, but contains glTF compatibility.
-// For the documentation on the values, please see the OBJ format.
+/// Material for surfaces, lines and triangles.
+/// For surfaces, uses a microfacet model with thin sheet transmission.
+/// The model is based on OBJ, but contains glTF compatibility.
+/// For the documentation on the values, please see the OBJ format.
 struct yocto_material {
   string uri = "";
 
@@ -149,14 +149,14 @@ struct yocto_material {
   int  normal_tex       = -1;
   bool gltf_textures    = false;  // glTF packed textures
 
-  // volume textures
+  /// volume textures
   int voldensity_tex = -1;
 };
 
-// Shape data represented as an indexed meshes of elements.
-// May contain either points, lines, triangles and quads.
-// Additionally, we support faceavarying primitives where each verftex data
-// has its own topology.
+/// Shape data represented as an indexed meshes of elements.
+/// May contain either points, lines, triangles and quads.
+/// Additionally, we support faceavarying primitives where each verftex data
+/// has its own topology.
 struct yocto_shape {
   // shape data
   string uri = "";
@@ -181,12 +181,12 @@ struct yocto_shape {
   vector<vec4f> tangents  = {};
 };
 
-// Shape data represented as an indexed meshes of elements.
-// This object exists only to allow for further subdivision. The current
-// subdiviion data is stored in the pointed to shape, so the rest of the system
-// does not need to known about subdivs. While this is mostly helpful for
-// subdivision surfaces, we store here all data that we possibly may want to
-// subdivide, for later use.
+/// Shape data represented as an indexed meshes of elements.
+/// This object exists only to allow for further subdivision. The current
+/// subdiviion data is stored in the pointed to shape, so the rest of the system
+/// does not need to known about subdivs. While this is mostly helpful for
+/// subdivision surfaces, we store here all data that we possibly may want to
+/// subdivide, for later use.
 struct yocto_subdiv {
   // shape data
   string uri = "";
@@ -223,7 +223,7 @@ struct yocto_subdiv {
   vector<float> radius    = {};
 };
 
-// Instance of a visible shape in the scene.
+/// Instance of a visible shape in the scene.
 struct yocto_instance {
   string  uri      = "";
   frame3f frame    = identity3x4f;
@@ -231,7 +231,7 @@ struct yocto_instance {
   int     material = -1;
 };
 
-// Environment map.
+/// Environment map.
 struct yocto_environment {
   string  uri          = "";
   frame3f frame        = identity3x4f;
@@ -239,7 +239,7 @@ struct yocto_environment {
   int     emission_tex = -1;
 };
 
-// Node in a transform hierarchy.
+/// Node in a transform hierarchy.
 struct yocto_scene_node {
   string        uri         = "";
   int           parent      = -1;
@@ -256,7 +256,7 @@ struct yocto_scene_node {
   vector<int> children = {};
 };
 
-// Keyframe data.
+/// Keyframe data.
 struct yocto_animation {
   enum struct interpolation_type { linear, step, bezier };
   string                uri           = "";
@@ -271,13 +271,13 @@ struct yocto_animation {
   vector<int>           targets       = {};
 };
 
-// Scene comprised an array of objects whose memory is owened by the scene.
-// All members are optional,Scene objects (camera, instances, environments)
-// have transforms defined internally. A scene can optionally contain a
-// node hierarchy where each node might point to a camera, instance or
-// environment. In that case, the element transforms are computed from
-// the hierarchy. Animation is also optional, with keyframe data that
-// updates node transformations only if defined.
+/// Scene comprised an array of objects whose memory is owened by the scene.
+/// All members are optional,Scene objects (camera, instances, environments)
+/// have transforms defined internally. A scene can optionally contain a
+/// node hierarchy where each node might point to a camera, instance or
+/// environment. In that case, the element transforms are computed from
+/// the hierarchy. Animation is also optional, with keyframe data that
+/// updates node transformations only if defined.
 struct yocto_scene {
   string                    uri          = "";
   vector<yocto_camera>      cameras      = {};
@@ -299,31 +299,31 @@ struct yocto_scene {
 // -----------------------------------------------------------------------------
 namespace yocto {
 
-// Merge a scene into another
+/// Merge a scene into another
 void merge_scene(yocto_scene& scene, const yocto_scene& merge);
 
-// Print scene statistics.
+/// Print scene statistics.
 string format_stats(
     const yocto_scene& scene, const string& prefix = "", bool verbose = false);
 
-// Add missing names, normals, tangents and hierarchy.
+/// Add missing names, normals, tangents and hierarchy.
 void add_normals(yocto_scene& scene);
 void add_tangent_spaces(yocto_scene& scene);
 void add_materials(yocto_scene& scene);
 void add_cameras(yocto_scene& scene);
 void add_radius(yocto_scene& scene, float radius = 0.001f);
 
-// Normalize URIs and add missing ones. Assumes names are unique.
+/// Normalize URIs and add missing ones. Assumes names are unique.
 void normalize_uris(yocto_scene& sceme);
 void rename_instances(yocto_scene& scene);
 
-// Add a sky environment
+/// Add a sky environment
 void add_sky(yocto_scene& scene, float sun_angle = pif / 4);
 
-// Reduce memory usage
+/// Reduce memory usage
 void trim_memory(yocto_scene& scene);
 
-// Checks for validity of the scene.
+/// Checks for validity of the scene.
 void print_validation(const yocto_scene& scene, bool notextures = false);
 
 }  // namespace yocto
@@ -333,23 +333,23 @@ void print_validation(const yocto_scene& scene, bool notextures = false);
 // -----------------------------------------------------------------------------
 namespace yocto {
 
-// Update node transforms.
+/// Update node transforms.
 void update_transforms(
     yocto_scene& scene, float time = 0, const string& anim_group = "");
 
-// Compute animation range.
+/// Compute animation range.
 vec2f compute_animation_range(
     const yocto_scene& scene, const string& anim_group = "");
 
-// Computes shape/scene approximate bounds.
+/// Computes shape/scene approximate bounds.
 bbox3f compute_bounds(const yocto_shape& shape);
 bbox3f compute_bounds(const yocto_scene& scene);
 
-// Compute shape vertex normals
+/// Compute shape vertex normals
 vector<vec3f> compute_normals(const yocto_shape& shape);
 void          compute_normals(const yocto_shape& shape, vector<vec3f>& normals);
 
-// Apply subdivision and displacement rules.
+/// Apply subdivision and displacement rules.
 void subdivide_shape(yocto_shape& shape, int subdivisions, bool catmullclark,
     bool compute_normals);
 void displace_shape(yocto_shape& shape, const yocto_texture& displacement,
@@ -357,15 +357,15 @@ void displace_shape(yocto_shape& shape, const yocto_texture& displacement,
 void tesselate_subdiv(yocto_scene& scene, yocto_subdiv& subdiv);
 void tesselate_subdivs(yocto_scene& scene);
 
-// Build/refit the bvh acceleration structure.
+/// Build/refit the bvh acceleration structure.
 bvh_scene make_bvh(const yocto_scene& scene, const bvh_params& params);
 void      make_bvh(
          bvh_scene& bvh, const yocto_scene& scene, const bvh_params& params);
 void refit_bvh(bvh_scene& bvh, const yocto_scene& scene,
     const vector<int>& updated_shapes, const bvh_params& params);
 
-// Shape values interpolated by interpoalting vertex values of the `eid` element
-// with its barycentric coordinates `euv`.
+/// Shape values interpolated by interpoalting vertex values of the `eid` element
+/// with its barycentric coordinates `euv`.
 vec3f eval_position(const yocto_shape& shape, int element, const vec2f& uv);
 vec3f eval_normal(const yocto_shape& shape, int element, const vec2f& uv);
 vec2f eval_texcoord(const yocto_shape& shape, int element, const vec2f& uv);
@@ -373,14 +373,14 @@ vec4f eval_color(const yocto_shape& shape, int element, const vec2f& uv);
 float eval_radius(const yocto_shape& shape, int element, const vec2f& uv);
 pair<mat3f, bool> eval_tangent_basis(
     const yocto_shape& shape, int element, const vec2f& uv);
-// Shape element values.
+/// Shape element values.
 vec3f              eval_element_normal(const yocto_shape& shape, int element);
 pair<vec3f, vec3f> eval_element_tangents(
     const yocto_shape& shape, int element, const vec2f& uv = zero2f);
 pair<mat3f, bool> eval_element_tangent_basis(
     const yocto_shape& shape, int element, const vec2f& uv = zero2f);
 
-// Sample a shape element based on area/length.
+/// Sample a shape element based on area/length.
 pair<int, vec2f> sample_shape(const yocto_shape& shape,
     const vector<float>& cdf, float re, const vec2f& ruv);
 vector<float>    sample_shape_cdf(const yocto_shape& shape);
@@ -388,7 +388,7 @@ void             sample_shape_cdf(const yocto_shape& shape, vector<float>& cdf);
 float sample_shape_pdf(const yocto_shape& shape, const vector<float>& cdf,
     int element, const vec2f& uv);
 
-// Evaluate a texture.
+/// Evaluate a texture.
 vec2i texture_size(const yocto_texture& texture);
 vec4f lookup_texture(
     const yocto_texture& texture, int i, int j, bool ldr_as_linear = false);
@@ -401,27 +401,27 @@ float eval_voltexture(const yocto_voltexture& texture, const vec3f& texcoord,
     bool ldr_as_linear = false, bool no_interpolation = false,
     bool clamp_to_edge = false);
 
-// Set and evaluate camera parameters. Setters take zeros as default values.
+/// Set and evaluate camera parameters. Setters take zeros as default values.
 vec2f camera_fov(const yocto_camera& camera);
 float camera_yfov(const yocto_camera& camera);
 float camera_aspect(const yocto_camera& camera);
 vec2i camera_resolution(const yocto_camera& camera, int resolution);
 void  set_yperspective(yocto_camera& camera, float yfov, float aspect,
      float focus, float film = 0.036f);
-// Sets camera field of view to enclose all the bbox. Camera view direction
-// fiom size and forcal lemgth can be overridden if we pass non zero values.
+/// Sets camera field of view to enclose all the bbox. Camera view direction
+/// fiom size and forcal lemgth can be overridden if we pass non zero values.
 void set_view(yocto_camera& camera, const bbox3f& bbox,
     const vec3f& view_direction = zero3f);
 
-// Generates a ray from the image coordinates `uv` and lens coordinates `luv`.
+/// Generates a ray from the image coordinates `uv` and lens coordinates `luv`.
 ray3f eval_camera(
     const yocto_camera& camera, const vec2f& uv, const vec2f& luv);
-// Generates a ray from a camera for pixel `ij`, the image size `resolution`,
-// the sub-pixel coordinates `puv` and the lens coordinates `luv`.
+/// Generates a ray from a camera for pixel `ij`, the image size `resolution`,
+/// the sub-pixel coordinates `puv` and the lens coordinates `luv`.
 ray3f eval_camera(const yocto_camera& camera, const vec2i& ij,
     const vec2i& resolution, const vec2f& puv, const vec2f& luv);
 
-// Material values packed into a convenience structure.
+/// Material values packed into a convenience structure.
 struct material_point {
   vec3f emission      = {0, 0, 0};
   vec3f diffuse       = {0, 0, 0};
@@ -440,8 +440,8 @@ material_point eval_material(const yocto_scene& scene,
     const yocto_material& material, const vec2f& texcoord,
     const vec4f& shape_color);
 
-// Instance values interpolated using barycentric coordinates.
-// Handles defaults if data is missing.
+/// Instance values interpolated using barycentric coordinates.
+/// Handles defaults if data is missing.
 vec3f eval_position(const yocto_scene& scene, const yocto_instance& instance,
     int element, const vec2f& uv);
 vec3f eval_normal(const yocto_scene& scene, const yocto_instance& instance,
@@ -454,19 +454,19 @@ vec3f eval_element_normal(const yocto_scene& scene,
 material_point eval_material(const yocto_scene& scene,
     const yocto_instance& instance, int element, const vec2f& uv);
 
-// Environment texture coordinates from the incoming direction.
+/// Environment texture coordinates from the incoming direction.
 vec2f eval_texcoord(
     const yocto_environment& environment, const vec3f& direction);
-// Evaluate the incoming direction from the uv.
+/// Evaluate the incoming direction from the uv.
 vec3f eval_direction(
     const yocto_environment& environment, const vec2f& environment_uv);
-// Evaluate the environment emission.
+/// Evaluate the environment emission.
 vec3f eval_environment(const yocto_scene& scene,
     const yocto_environment& environment, const vec3f& direction);
-// Evaluate all environment emission.
+/// Evaluate all environment emission.
 vec3f eval_environment(const yocto_scene& scene, const vec3f& direction);
 
-// Sample an environment based on either texel values of uniform
+/// Sample an environment based on either texel values of uniform
 vec3f         sample_environment(const yocto_scene& scene,
             const yocto_environment& environment, const vector<float>& texels_cdf,
             float re, const vec2f& ruv);
@@ -485,25 +485,25 @@ float sample_environment_pdf(const yocto_scene& scene,
 // -----------------------------------------------------------------------------
 namespace yocto {
 
-// Find the first keyframe value that is greater than the argument.
+/// Find the first keyframe value that is greater than the argument.
 inline int keyframe_index(const vector<float>& times, const float& time);
 
-// Evaluates a keyframed value using step interpolation.
+/// Evaluates a keyframed value using step interpolation.
 template <typename T>
 inline T keyframe_step(
     const vector<float>& times, const vector<T>& vals, float time);
 
-// Evaluates a keyframed value using linear interpolation.
+/// Evaluates a keyframed value using linear interpolation.
 template <typename T>
 inline vec4f keyframe_slerp(
     const vector<float>& times, const vector<vec4f>& vals, float time);
 
-// Evaluates a keyframed value using linear interpolation.
+/// Evaluates a keyframed value using linear interpolation.
 template <typename T>
 inline T keyframe_linear(
     const vector<float>& times, const vector<T>& vals, float time);
 
-// Evaluates a keyframed value using Bezier interpolation.
+/// Evaluates a keyframed value using Bezier interpolation.
 template <typename T>
 inline T keyframe_bezier(
     const vector<float>& times, const vector<T>& vals, float time);
@@ -515,14 +515,14 @@ inline T keyframe_bezier(
 // -----------------------------------------------------------------------------
 namespace yocto {
 
-// Find the first keyframe value that is greater than the argument.
+/// Find the first keyframe value that is greater than the argument.
 inline int keyframe_index(const vector<float>& times, const float& time) {
   for (auto i = 0; i < times.size(); i++)
     if (times[i] > time) return i;
   return (int)times.size();
 }
 
-// Evaluates a keyframed value using step interpolation.
+/// Evaluates a keyframed value using step interpolation.
 template <typename T>
 inline T keyframe_step(
     const vector<float>& times, const vector<T>& vals, float time) {
@@ -533,7 +533,7 @@ inline T keyframe_step(
   return vals.at(idx - 1);
 }
 
-// Evaluates a keyframed value using linear interpolation.
+/// Evaluates a keyframed value using linear interpolation.
 template <typename T>
 inline vec4f keyframe_slerp(
     const vector<float>& times, const vector<vec4f>& vals, float time) {
@@ -545,7 +545,7 @@ inline vec4f keyframe_slerp(
   return slerp(vals.at(idx - 1), vals.at(idx), t);
 }
 
-// Evaluates a keyframed value using linear interpolation.
+/// Evaluates a keyframed value using linear interpolation.
 template <typename T>
 inline T keyframe_linear(
     const vector<float>& times, const vector<T>& vals, float time) {
@@ -557,7 +557,7 @@ inline T keyframe_linear(
   return vals.at(idx - 1) * (1 - t) + vals.at(idx) * t;
 }
 
-// Evaluates a keyframed value using Bezier interpolation.
+/// Evaluates a keyframed value using Bezier interpolation.
 template <typename T>
 inline T keyframe_bezier(
     const vector<float>& times, const vector<T>& vals, float time) {

--- a/yocto/yocto_sceneio.h
+++ b/yocto/yocto_sceneio.h
@@ -1,19 +1,19 @@
-//
-// # Yocto/SceneIO: Tiny library for Yocto/Scene input and output
-//
-// Yocto/SceneIO provides loading and saving functionality for scenes
-// in Yocto/GL. We support a simple to use YAML format, PLY, OBJ and glTF.
-// The YAML serialization is a straight copy of the in-memory scene data.
-// To speed up testing, we also support a binary format that is a dump of
-// the current scene. This format should not be use for archival though.
-//
-// Error reporting is done through exceptions using the `io_error` exception.
-//
-// ## Scene Loading and Saving
-//
-// 1. load a scene with `load_scene()` and save it with `save_scene()`
-//
-//
+///
+/// # Yocto/SceneIO: Tiny library for Yocto/Scene input and output
+///
+/// Yocto/SceneIO provides loading and saving functionality for scenes
+/// in Yocto/GL. We support a simple to use YAML format, PLY, OBJ and glTF.
+/// The YAML serialization is a straight copy of the in-memory scene data.
+/// To speed up testing, we also support a binary format that is a dump of
+/// the current scene. This format should not be use for archival though.
+///
+/// Error reporting is done through exceptions using the `io_error` exception.
+///
+/// ## Scene Loading and Saving
+///
+/// 1. load a scene with `load_scene()` and save it with `save_scene()`
+///
+///
 
 //
 // LICENSE:
@@ -55,7 +55,7 @@
 
 namespace yocto {
 
-// Scene load params
+/// Scene load params
 struct load_params {
   bool               notextures  = false;
   bool               facevarying = false;
@@ -63,7 +63,7 @@ struct load_params {
   bool               noparallel  = false;
 };
 
-// Scene save params
+/// Scene save params
 struct save_params {
   bool               notextures   = false;
   bool               objinstances = false;
@@ -71,13 +71,13 @@ struct save_params {
   bool               noparallel   = false;
 };
 
-// Load/save a scene in the supported formats.
+/// Load/save a scene in the supported formats.
 void load_scene(
     const string& filename, yocto_scene& scene, const load_params& params = {});
 void save_scene(const string& filename, const yocto_scene& scene,
     const save_params& params = {});
 
-// Load/save scene textures
+/// Load/save scene textures
 void load_texture(yocto_texture& texture, const string& dirname);
 void save_texture(const yocto_texture& texture, const string& dirname);
 void load_voltexture(yocto_voltexture& texture, const string& dirname);
@@ -87,7 +87,7 @@ void load_textures(
 void save_textures(
     const yocto_scene& scene, const string& dirname, const save_params& params);
 
-// Load/save scene shapes
+/// Load/save scene shapes
 void load_shape(yocto_shape& shape, const string& dirname);
 void save_shape(const yocto_shape& shape, const string& dirname);
 void load_subdiv(yocto_subdiv& subdiv, const string& dirname);

--- a/yocto/yocto_shape.h
+++ b/yocto/yocto_shape.h
@@ -1,71 +1,71 @@
-//
-// # Yocto/Shape: Tiny Library for shape operations for graphics
-//
-//
-// Yocto/Shape is a collection of utilities for manipulating shapes in 3D
-// graphics, with a focus on triangle and quad meshes. We support both low-level
-// geometry operation and whole shape operations.
-//
-//
-// ## Geometry functions
-//
-// The library supports basic geomtry functions such as computing
-// line/triangle/quad normals and areas, picking points on triangles
-// and the like. In these functions triangles are parameterized with us written
-// w.r.t the (p1-p0) and (p2-p0) axis respectively. Quads are internally handled
-// as pairs of two triangles p0,p1,p3 and p2,p3,p1, with the u/v coordinates
-// of the second triangle corrected as 1-u and 1-v to produce a quad
-// parametrization where u and v go from 0 to 1. Degenerate quads with p2==p3
-// represent triangles correctly, an this convention is used throught the
-// library. This is equivalent to Intel's Embree.
-//
-//
-// ## Shape functions
-//
-// We provide a small number of utilities for shape manipulation for index
-// triangle and quad meshes, indexed line and point sets and indexed beziers.
-// The utliities collected here are written to support a global illumination
-// rendering and not for generic geometry processing. We support operation for
-// shape smoothing, shape subdivision (including Catmull-Clark subdivs), and
-// example shape creation.
-//
-// 1. compute line tangents, and triangle and quad areas and normals with
-//    `line_tangent()`, `triamgle_normal()`, `quad_normal()` and
-//    `line_length()`, `triangle_area()` and `quad_normal()`
-// 2. interpolate values over primitives with `interpolate_line()`,
-//    `interpolate_triangle()` and `interpolate_quad()`
-// 3. evaluate Bezier curves and derivatives with `interpolate_bezier()` and
-//    `interpolate_bezier_derivative()`
-// 4. compute smooth normals and tangents with `compute_normals()`
-//   `compute_tangents()`
-// 5. compute tangent frames from texture coordinates with
-//    `compute_tangent_spaces()`
-// 6. compute skinning with `compute_skinning()` and
-//    `compute_matrix_skinning()`
-// 6. create shapes with `make_proc_image()`, `make_hair()`,
-// `make_points()`
-// 7. merge element with `marge_lines()`, `marge_triangles()`, `marge_quads()`
-// 8. shape sampling with `sample_points()`, `sample_lines()`,
-//    `sample_triangles()`; initialize the sampling CDFs with
-//    `sample_points_cdf()`, `sample_lines_cdf()`,
-//    `sample_triangles_cdf()`
-// 9.  sample a could of point over a surface with `sample_triangles()`
-// 10. get edges and boundaries with `get_edges()`
-// 11. convert quads to triangles with `quads_to_triangles()`
-// 12. convert face varying to vertex shared representations with
-//     `convert_face_varying()`
-// 13. subdivide elements by edge splits with `subdivide_lines()`,
-//     `subdivide_triangles()`, `subdivide_quads()`, `subdivide_beziers()`
-// 14. Catmull-Clark subdivision surface with `subdivide_catmullclark()`
-//
-//
-// ## Shape IO
-//
-// We support reading and writing shapes in OBJ and PLY.
-//
-// 1. load/save shapes with `load_shape()`/`save_shape()`
-//
-//
+///
+/// # Yocto/Shape: Tiny Library for shape operations for graphics
+///
+///
+/// Yocto/Shape is a collection of utilities for manipulating shapes in 3D
+/// graphics, with a focus on triangle and quad meshes. We support both low-level
+/// geometry operation and whole shape operations.
+///
+///
+/// ## Geometry functions
+///
+/// The library supports basic geomtry functions such as computing
+/// line/triangle/quad normals and areas, picking points on triangles
+/// and the like. In these functions triangles are parameterized with us written
+/// w.r.t the (p1-p0) and (p2-p0) axis respectively. Quads are internally handled
+/// as pairs of two triangles p0,p1,p3 and p2,p3,p1, with the u/v coordinates
+/// of the second triangle corrected as 1-u and 1-v to produce a quad
+/// parametrization where u and v go from 0 to 1. Degenerate quads with p2==p3
+/// represent triangles correctly, an this convention is used throught the
+/// library. This is equivalent to Intel's Embree.
+///
+///
+/// ## Shape functions
+///
+/// We provide a small number of utilities for shape manipulation for index
+/// triangle and quad meshes, indexed line and point sets and indexed beziers.
+/// The utliities collected here are written to support a global illumination
+/// rendering and not for generic geometry processing. We support operation for
+/// shape smoothing, shape subdivision (including Catmull-Clark subdivs), and
+/// example shape creation.
+///
+/// 1. compute line tangents, and triangle and quad areas and normals with
+///    `line_tangent()`, `triamgle_normal()`, `quad_normal()` and
+///    `line_length()`, `triangle_area()` and `quad_normal()`
+/// 2. interpolate values over primitives with `interpolate_line()`,
+///    `interpolate_triangle()` and `interpolate_quad()`
+/// 3. evaluate Bezier curves and derivatives with `interpolate_bezier()` and
+///    `interpolate_bezier_derivative()`
+/// 4. compute smooth normals and tangents with `compute_normals()`
+///   `compute_tangents()`
+/// 5. compute tangent frames from texture coordinates with
+///    `compute_tangent_spaces()`
+/// 6. compute skinning with `compute_skinning()` and
+///    `compute_matrix_skinning()`
+/// 6. create shapes with `make_proc_image()`, `make_hair()`,
+/// `make_points()`
+/// 7. merge element with `marge_lines()`, `marge_triangles()`, `marge_quads()`
+/// 8. shape sampling with `sample_points()`, `sample_lines()`,
+///    `sample_triangles()`; initialize the sampling CDFs with
+///    `sample_points_cdf()`, `sample_lines_cdf()`,
+///    `sample_triangles_cdf()`
+/// 9.  sample a could of point over a surface with `sample_triangles()`
+/// 10. get edges and boundaries with `get_edges()`
+/// 11. convert quads to triangles with `quads_to_triangles()`
+/// 12. convert face varying to vertex shared representations with
+///     `convert_face_varying()`
+/// 13. subdivide elements by edge splits with `subdivide_lines()`,
+///     `subdivide_triangles()`, `subdivide_quads()`, `subdivide_beziers()`
+/// 14. Catmull-Clark subdivision surface with `subdivide_catmullclark()`
+///
+///
+/// ## Shape IO
+///
+/// We support reading and writing shapes in OBJ and PLY.
+///
+/// 1. load/save shapes with `load_shape()`/`save_shape()`
+///
+///
 
 //
 // LICENSE:
@@ -110,7 +110,7 @@
 // -----------------------------------------------------------------------------
 namespace yocto {
 
-// Compute per-vertex normals/tangents for lines/triangles/quads.
+/// Compute per-vertex normals/tangents for lines/triangles/quads.
 vector<vec3f> compute_tangents(
     const vector<vec2i>& lines, const vector<vec3f>& positions);
 vector<vec3f> compute_normals(
@@ -124,11 +124,11 @@ void compute_normals(vector<vec3f>& normals, const vector<vec3i>& triangles,
 void compute_normals(vector<vec3f>& normals, const vector<vec4i>& quads,
     const vector<vec3f>& positions);
 
-// Compute per-vertex tangent space for triangle meshes.
-// Tangent space is defined by a four component vector.
-// The first three components are the tangent with respect to the u texcoord.
-// The fourth component is the sign of the tangent wrt the v texcoord.
-// Tangent frame is useful in normal mapping.
+/// Compute per-vertex tangent space for triangle meshes.
+/// Tangent space is defined by a four component vector.
+/// The first three components are the tangent with respect to the u texcoord.
+/// The fourth component is the sign of the tangent wrt the v texcoord.
+/// Tangent frame is useful in normal mapping.
 vector<vec4f> compute_tangent_spaces(const vector<vec3i>& triangles,
     const vector<vec3f>& positions, const vector<vec3f>& normals,
     const vector<vec2f>& texcoords);
@@ -136,7 +136,7 @@ void          compute_tangent_spaces(vector<vec4f>& tangents,
              const vector<vec3i>& triangles, const vector<vec3f>& positions,
              const vector<vec3f>& normals, const vector<vec2f>& texcoords);
 
-// Apply skinning to vertex position and normals.
+/// Apply skinning to vertex position and normals.
 pair<vector<vec3f>, vector<vec3f>> compute_skinning(
     const vector<vec3f>& positions, const vector<vec3f>& normals,
     const vector<vec4f>& weights, const vector<vec4i>& joints,
@@ -145,7 +145,7 @@ void compute_skinning(vector<vec3f>& skinned_positions,
     vector<vec3f>& skinned_normals, const vector<vec3f>& positions,
     const vector<vec3f>& normals, const vector<vec4f>& weights,
     const vector<vec4i>& joints, const vector<frame3f>& xforms);
-// Apply skinning as specified in Khronos glTF.
+/// Apply skinning as specified in Khronos glTF.
 pair<vector<vec3f>, vector<vec3f>> compute_matrix_skinning(
     const vector<vec3f>& positions, const vector<vec3f>& normals,
     const vector<vec4f>& weights, const vector<vec4i>& joints,
@@ -162,15 +162,15 @@ void compute_matrix_skinning(vector<vec3f>& skinned_positions,
 // -----------------------------------------------------------------------------
 namespace yocto {
 
-// Flip vertex normals
+/// Flip vertex normals
 vector<vec3f> flip_normals(const vector<vec3f>& normals);
 void flip_normals(vector<vec3f>& flipped, const vector<vec3f>& normals);
-// Flip face orientation
+/// Flip face orientation
 vector<vec3i> flip_triangles(const vector<vec3i>& triangles);
 vector<vec4i> flip_quads(const vector<vec4i>& quads);
 void flip_triangles(vector<vec3i>& flipped, const vector<vec3i>& triangles);
 void flip_quads(vector<vec4i>& flipped, const vector<vec4i>& quads);
-// Align vertex positions. Alignment is 0: none, 1: min, 2: max, 3: center.
+/// Align vertex positions. Alignment is 0: none, 1: min, 2: max, 3: center.
 vector<vec3f> align_vertices(
     const vector<vec3f>& positions, const vec3i& alignment);
 void align_vertices(vector<vec3f>& aligned, const vector<vec3f>& positions,
@@ -183,26 +183,26 @@ void align_vertices(vector<vec3f>& aligned, const vector<vec3f>& positions,
 // -----------------------------------------------------------------------------
 namespace yocto {
 
-// Dictionary to store edge information. `index` is the index to the edge
-// array, `edges` the array of edges and `nfaces` the number of adjacent faces.
-// We store only bidirectional edges to keep the dictionary small. Use the
-// functions below to access this data.
+/// Dictionary to store edge information. `index` is the index to the edge
+/// array, `edges` the array of edges and `nfaces` the number of adjacent faces.
+/// We store only bidirectional edges to keep the dictionary small. Use the
+/// functions below to access this data.
 struct edge_map {
   unordered_map<vec2i, int> index  = {};
   vector<vec2i>             edges  = {};
   vector<int>               nfaces = {};
 };
 
-// Initialize an edge map with elements.
+/// Initialize an edge map with elements.
 edge_map make_edge_map(const vector<vec3i>& triangles);
 edge_map make_edge_map(const vector<vec4i>& quads);
 void     insert_edges(edge_map& emap, const vector<vec3i>& triangles);
 void     insert_edges(edge_map& emap, const vector<vec4i>& quads);
-// Insert an edge and return its index
+/// Insert an edge and return its index
 int insert_edge(edge_map& emap, const vec2i& edge);
-// Get the edge index / insertion count
+/// Get the edge index / insertion count
 int edge_index(const edge_map& emap, const vec2i& edge);
-// Get list of edges / boundary edges
+/// Get list of edges / boundary edges
 int           num_edges(const edge_map& emap);
 vector<vec2i> get_edges(const edge_map& emap);
 vector<vec2i> get_boundary(const edge_map& emap);
@@ -211,8 +211,8 @@ void          get_boundary(const edge_map& emap, vector<vec2i>& edges);
 vector<vec2i> get_edges(const vector<vec3i>& triangles);
 vector<vec2i> get_edges(const vector<vec4i>& quads);
 
-// A sparse grid of cells, containing list of points. Cells are stored in
-// a dictionary to get sparsity. Helpful for nearest neighboor lookups.
+/// A sparse grid of cells, containing list of points. Cells are stored in
+/// a dictionary to get sparsity. Helpful for nearest neighboor lookups.
 struct hash_grid {
   float                             cell_size     = 0;
   float                             cell_inv_size = 0;
@@ -220,12 +220,12 @@ struct hash_grid {
   unordered_map<vec3i, vector<int>> cells         = {};
 };
 
-// Create a hash_grid
+/// Create a hash_grid
 hash_grid make_hash_grid(float cell_size);
 hash_grid make_hash_grid(const vector<vec3f>& positions, float cell_size);
-// Inserts a point into the grid
+/// Inserts a point into the grid
 int insert_vertex(hash_grid& grid, const vec3f& position);
-// Finds the nearest neighboors within a given radius
+/// Finds the nearest neighboors within a given radius
 void find_neightbors(const hash_grid& grid, vector<int>& neighboors,
     const vec3f& position, float max_radius);
 void find_neightbors(const hash_grid& grid, vector<int>& neighboors, int vertex,
@@ -238,19 +238,19 @@ void find_neightbors(const hash_grid& grid, vector<int>& neighboors, int vertex,
 // -----------------------------------------------------------------------------
 namespace yocto {
 
-// Convert quads to triangles
+/// Convert quads to triangles
 vector<vec3i> quads_to_triangles(const vector<vec4i>& quads);
 void quads_to_triangles(vector<vec3i>& triangles, const vector<vec4i>& quads);
-// Convert triangles to quads by creating degenerate quads
+/// Convert triangles to quads by creating degenerate quads
 vector<vec4i> triangles_to_quads(const vector<vec3i>& triangles);
 void triangles_to_quads(vector<vec4i>& quads, const vector<vec3i>& triangles);
 
-// Convert beziers to lines using 3 lines for each bezier.
+/// Convert beziers to lines using 3 lines for each bezier.
 vector<vec4i> bezier_to_lines(vector<vec2i>& lines);
 void bezier_to_lines(vector<vec2i>& lines, const vector<vec4i>& beziers);
 
-// Convert face-varying data to single primitives. Returns the quads indices
-// and face ids and filled vectors for pos, norm, texcoord and colors.
+/// Convert face-varying data to single primitives. Returns the quads indices
+/// and face ids and filled vectors for pos, norm, texcoord and colors.
 void split_facevarying(vector<vec4i>& split_quads,
     vector<vec3f>& split_positions, vector<vec3f>& split_normals,
     vector<vec2f>& split_texcoords, const vector<vec4i>& quadspos,
@@ -258,7 +258,7 @@ void split_facevarying(vector<vec4i>& split_quads,
     const vector<vec3f>& positions, const vector<vec3f>& normals,
     const vector<vec2f>& texcoords);
 
-// Split primitives per id
+/// Split primitives per id
 vector<vector<vec2i>> ungroup_lines(
     const vector<vec2i>& lines, const vector<int>& ids);
 vector<vector<vec3i>> ungroup_triangles(
@@ -272,7 +272,7 @@ void ungroup_triangles(vector<vector<vec3i>>& split_triangles,
 void ungroup_quads(vector<vector<vec4i>>& split_quads,
     const vector<vec4i>& quads, const vector<int>& ids);
 
-// Weld vertices within a threshold.
+/// Weld vertices within a threshold.
 pair<vector<vec3f>, vector<int>> weld_vertices(
     const vector<vec3f>& positions, float threshold);
 pair<vector<vec3i>, vector<vec3f>> weld_triangles(
@@ -280,7 +280,7 @@ pair<vector<vec3i>, vector<vec3f>> weld_triangles(
     float threshold);
 pair<vector<vec4i>, vector<vec3f>> weld_quads(const vector<vec4i>& quads,
     const vector<vec3f>& positions, float threshold);
-// Weld vertices within a threshold.
+/// Weld vertices within a threshold.
 void weld_vertices(vector<vec3f>& welded_positions, vector<int>& indices,
     const vector<vec3f>& positions, float threshold);
 void weld_triangles(vector<vec3i>& welded_triangles,
@@ -290,7 +290,7 @@ void weld_quads(vector<vec4i>& welded_quads, vector<vec3f>& welded_positions,
     const vector<vec4i>& quads, const vector<vec3f>& positions,
     float threshold);
 
-// Merge shape elements
+/// Merge shape elements
 void merge_lines(
     vector<vec2i>& lines, const vector<vec2i>& merge_lines, int num_verts);
 void merge_triangles(vector<vec3i>& triangles,
@@ -314,7 +314,7 @@ void merge_quads(vector<vec4i>& quads, vector<vec3f>& positions,
     const vector<vec3f>& merge_normals,
     const vector<vec2f>& merge_texturecoords);
 
-// Merge quads and triangles
+/// Merge quads and triangles
 void merge_triangles_and_quads(
     vector<vec3i>& triangles, vector<vec4i>& quads, bool force_triangles);
 
@@ -325,7 +325,7 @@ void merge_triangles_and_quads(
 // -----------------------------------------------------------------------------
 namespace yocto {
 
-// Subdivide lines by splitting each line in half.
+/// Subdivide lines by splitting each line in half.
 pair<vector<vec2i>, vector<float>> subdivide_lines(
     const vector<vec2i>& lines, const vector<float>& vert, int level);
 pair<vector<vec2i>, vector<vec2f>> subdivide_lines(
@@ -348,8 +348,8 @@ void subdivide_lines(vector<vec2i>& slines, vector<vec3f>& spositions,
     const vector<vec3f>& positions, const vector<vec3f>& normals,
     const vector<vec2f>& texcoords, const vector<vec4f>& colors,
     const vector<float>& radius, int level);
-// Subdivide triangle by splitting each triangle in four, creating new
-// vertices for each edge.
+/// Subdivide triangle by splitting each triangle in four, creating new
+/// vertices for each edge.
 pair<vector<vec3i>, vector<float>> subdivide_triangles(
     const vector<vec3i>& triangles, const vector<float>& vert, int level);
 pair<vector<vec3i>, vector<vec2f>> subdivide_triangles(
@@ -372,8 +372,8 @@ void subdivide_triangles(vector<vec3i>& striangles, vector<vec3f>& spositions,
     const vector<vec3f>& positions, const vector<vec3f>& normals,
     const vector<vec2f>& texcoords, const vector<vec4f>& colors,
     const vector<float>& radius, int level);
-// Subdivide quads by splitting each quads in four, creating new
-// vertices for each edge and for each face.
+/// Subdivide quads by splitting each quads in four, creating new
+/// vertices for each edge and for each face.
 pair<vector<vec4i>, vector<float>> subdivide_quads(
     const vector<vec4i>& quads, const vector<float>& vert, int level);
 pair<vector<vec4i>, vector<vec2f>> subdivide_quads(
@@ -396,7 +396,7 @@ void subdivide_quads(vector<vec4i>& squads, vector<vec3f>& spositions,
     const vector<vec3f>& positions, const vector<vec3f>& normals,
     const vector<vec2f>& texcoords, const vector<vec4f>& colors,
     const vector<float>& radius, int level);
-// Subdivide beziers by splitting each segment in two.
+/// Subdivide beziers by splitting each segment in two.
 pair<vector<vec4i>, vector<float>> subdivide_beziers(
     const vector<vec4i>& beziers, const vector<float>& vert, int level);
 pair<vector<vec4i>, vector<vec2f>> subdivide_beziers(
@@ -419,7 +419,7 @@ void subdivide_beziers(vector<vec4i>& sbeziers, vector<vec3f>& spositions,
     const vector<vec3f>& positions, const vector<vec3f>& normals,
     const vector<vec2f>& texcoords, const vector<vec4f>& colors,
     const vector<float>& radius, int level);
-// Subdivide quads using Carmull-Clark subdivision rules.
+/// Subdivide quads using Carmull-Clark subdivision rules.
 pair<vector<vec4i>, vector<float>> subdivide_catmullclark(
     const vector<vec4i>& quads, const vector<float>& vert, int level,
     bool lock_boundary = false);
@@ -458,20 +458,20 @@ void subdivide_catmullclark(vector<vec4i>& squads, vector<vec3f>& spositions,
 // -----------------------------------------------------------------------------
 namespace yocto {
 
-// Pick a point in a point set uniformly.
+/// Pick a point in a point set uniformly.
 int           sample_points(int npoints, float re);
 int           sample_points(const vector<float>& cdf, float re);
 vector<float> sample_points_cdf(int npoints);
 void          sample_points_cdf(vector<float>& cdf, int npoints);
 
-// Pick a point on lines uniformly.
+/// Pick a point on lines uniformly.
 pair<int, float> sample_lines(const vector<float>& cdf, float re, float ru);
 vector<float>    sample_lines_cdf(
        const vector<vec2i>& lines, const vector<vec3f>& positions);
 void sample_lines_cdf(vector<float>& cdf, const vector<vec2i>& lines,
     const vector<vec3f>& positions);
 
-// Pick a point on a triangle mesh uniformly.
+/// Pick a point on a triangle mesh uniformly.
 pair<int, vec2f> sample_triangles(
     const vector<float>& cdf, float re, const vec2f& ruv);
 vector<float> sample_triangles_cdf(
@@ -479,7 +479,7 @@ vector<float> sample_triangles_cdf(
 void sample_triangles_cdf(vector<float>& cdf, const vector<vec3i>& triangles,
     const vector<vec3f>& positions);
 
-// Pick a point on a quad mesh uniformly.
+/// Pick a point on a quad mesh uniformly.
 pair<int, vec2f> sample_quads(
     const vector<float>& cdf, float re, const vec2f& ruv);
 pair<int, vec2f> sample_quads(const vector<vec4i>& quads,
@@ -489,8 +489,8 @@ vector<float>    sample_quads_cdf(
 void sample_quads_cdf(vector<float>& cdf, const vector<vec4i>& quads,
     const vector<vec3f>& positions);
 
-// Samples a set of points over a triangle/quad mesh uniformly. Returns pos,
-// norm and texcoord of the sampled points.
+/// Samples a set of points over a triangle/quad mesh uniformly. Returns pos,
+/// norm and texcoord of the sampled points.
 void sample_triangles(vector<vec3f>& sampled_positions,
     vector<vec3f>& sampled_normals, vector<vec2f>& sampled_texturecoords,
     const vector<vec3i>& triangles, const vector<vec3f>& positions,
@@ -509,7 +509,7 @@ void sample_quads(vector<vec3f>& sampled_positions,
 // -----------------------------------------------------------------------------
 namespace yocto {
 
-// Data structure used for geodesic computation
+/// Data structure used for geodesic computation
 struct geodesic_solver {
   struct arc_ {
     int   node   = 0;
@@ -525,7 +525,7 @@ struct geodesic_solver {
   vector<vec2i>          edges      = {};
 };
 
-// Construct an edge graph
+/// Construct an edge graph
 void init_geodesic_solver(geodesic_solver& solver,
     const vector<vec3i>& triangles, const vector<vec3f>& positions);
 void compute_geodesic_distances(geodesic_solver& solver,
@@ -540,7 +540,7 @@ void convert_distance_to_color(
 // -----------------------------------------------------------------------------
 namespace yocto {
 
-// Load/Save a shape
+/// Load/Save a shape
 void load_shape(const string& filename, vector<int>& points,
     vector<vec2i>& lines, vector<vec3i>& triangles, vector<vec4i>& quads,
     vector<vec4i>& quadspos, vector<vec4i>& quadsnorm,
@@ -562,7 +562,7 @@ void save_shape(const string& filename, const vector<int>& points,
 // -----------------------------------------------------------------------------
 namespace yocto {
 
-// Parameters for make shape function
+/// Parameters for make shape function
 struct proc_shape_params {
   // clang-format off
   enum struct type_t {
@@ -574,28 +574,28 @@ struct proc_shape_params {
   float   scale        = 1;
   float   uvscale      = 1;
   float   rounded      = 0;
-  vec3f   aspect       = {1, 1, 1};  // for rect, box, cylinder
+  vec3f   aspect       = {1, 1, 1};  /// for rect, box, cylinder
   frame3f frame        = identity3x4f;
 };
 
-// Make a procedural shape
+/// Make a procedural shape
 void make_proc_shape(vector<vec3i>& triangles, vector<vec4i>& quads,
     vector<vec3f>& positions, vector<vec3f>& normals, vector<vec2f>& texcoords,
     const proc_shape_params& params);
-// Make face-varying quads. For now supports only quad, cube, suzanne, sphere,
-// rect, box. Rounding not supported for now.
+/// Make face-varying quads. For now supports only quad, cube, suzanne, sphere,
+/// rect, box. Rounding not supported for now.
 void make_proc_fvshape(vector<vec4i>& quadspos, vector<vec4i>& quadsnorm,
     vector<vec4i>& quadstexcoord, vector<vec3f>& positions,
     vector<vec3f>& normals, vector<vec2f>& texcoords,
     const proc_shape_params& params);
 
-// Generate lines set along a quad. Returns lines, pos, norm, texcoord, radius.
+/// Generate lines set along a quad. Returns lines, pos, norm, texcoord, radius.
 void make_lines(vector<vec2i>& lines, vector<vec3f>& positions,
     vector<vec3f>& normals, vector<vec2f>& texcoords, vector<float>& radius,
     int num, int subdivisions, const vec2f& size, const vec2f& uvsize,
     const vec2f& line_radius);
 
-// Make point primitives. Returns points, pos, norm, texcoord, radius.
+/// Make point primitives. Returns points, pos, norm, texcoord, radius.
 void make_points(vector<int>& points, vector<vec3f>& positions,
     vector<vec3f>& normals, vector<vec2f>& texcoords, vector<float>& radius,
     int num, float uvsize, float point_radius);
@@ -604,7 +604,7 @@ void make_random_points(vector<int>& points, vector<vec3f>& positions,
     int num, const vec3f& size, float uvsize, float point_radius,
     uint64_t seed);
 
-// Make fair params
+/// Make fair params
 struct hair_params {
   int   num               = 0;
   int   subdivisions      = 0;
@@ -621,25 +621,25 @@ struct hair_params {
   int   seed              = 7;
 };
 
-// Make a hair ball around a shape.  Returns lines, pos, norm, texcoord, radius.
-// length: minimum and maximum length
-// rad: minimum and maximum radius from base to tip
-// noise: noise added to hair (strength/scale)
-// clump: clump added to hair (number/strength)
-// rotation: rotation added to hair (angle/strength)
+/// Make a hair ball around a shape.  Returns lines, pos, norm, texcoord, radius.
+/// length: minimum and maximum length
+/// rad: minimum and maximum radius from base to tip
+/// noise: noise added to hair (strength/scale)
+/// clump: clump added to hair (number/strength)
+/// rotation: rotation added to hair (angle/strength)
 void make_hair(vector<vec2i>& lines, vector<vec3f>& positions,
     vector<vec3f>& normals, vector<vec2f>& texcoords, vector<float>& radius,
     const vector<vec3i>& striangles, const vector<vec4i>& squads,
     const vector<vec3f>& spos, const vector<vec3f>& snorm,
     const vector<vec2f>& stexcoord, const hair_params& params);
 
-// Thickens a shape by copying the shape content, rescaling it and flipping its
-// normals. Note that this is very much not robust and only useful for trivial
-// cases.
+/// Thickens a shape by copying the shape content, rescaling it and flipping its
+/// normals. Note that this is very much not robust and only useful for trivial
+/// cases.
 void make_shell(vector<vec4i>& quads, vector<vec3f>& positions,
     vector<vec3f>& normals, vector<vec2f>& texcoords, float thickness);
 
-// Shape presets used ofr testing.
+/// Shape presets used ofr testing.
 void make_shape_preset(vector<int>& points, vector<vec2i>& lines,
     vector<vec3i>& triangles, vector<vec4i>& quads, vector<vec4i>& quadspos,
     vector<vec4i>& quadsnorm, vector<vec4i>& quadstexcoord,
@@ -653,7 +653,7 @@ void make_shape_preset(vector<int>& points, vector<vec2i>& lines,
 // -----------------------------------------------------------------------------
 namespace yocto {
 
-// Line properties.
+/// Line properties.
 inline vec3f line_tangent(const vec3f& p0, const vec3f& p1) {
   return normalize(p1 - p0);
 }
@@ -661,7 +661,7 @@ inline float line_length(const vec3f& p0, const vec3f& p1) {
   return length(p1 - p0);
 }
 
-// Triangle properties.
+/// Triangle properties.
 inline vec3f triangle_normal(
     const vec3f& p0, const vec3f& p1, const vec3f& p2) {
   return normalize(cross(p1 - p0, p2 - p0));
@@ -670,7 +670,7 @@ inline float triangle_area(const vec3f& p0, const vec3f& p1, const vec3f& p2) {
   return length(cross(p1 - p0, p2 - p0)) / 2;
 }
 
-// Quad propeties.
+/// Quad propeties.
 inline vec3f quad_normal(
     const vec3f& p0, const vec3f& p1, const vec3f& p2, const vec3f& p3) {
   return normalize(triangle_normal(p0, p1, p3) + triangle_normal(p2, p3, p1));
@@ -680,32 +680,32 @@ inline float quad_area(
   return triangle_area(p0, p1, p3) + triangle_area(p2, p3, p1);
 }
 
-// Triangle tangent and bitangent from uv
+/// Triangle tangent and bitangent from uv
 inline pair<vec3f, vec3f> triangle_tangents_fromuv(const vec3f& p0,
     const vec3f& p1, const vec3f& p2, const vec2f& uv0, const vec2f& uv1,
     const vec2f& uv2);
 
-// Quad tangent and bitangent from uv. Note that we pass a current_uv since
-// internally we may want to split the quad in two and we need to known where
-// to do it. If not interested in the split, just pass zero2f here.
+/// Quad tangent and bitangent from uv. Note that we pass a current_uv since
+/// internally we may want to split the quad in two and we need to known where
+/// to do it. If not interested in the split, just pass zero2f here.
 inline pair<vec3f, vec3f> quad_tangents_fromuv(const vec3f& p0, const vec3f& p1,
     const vec3f& p2, const vec3f& p3, const vec2f& uv0, const vec2f& uv1,
     const vec2f& uv2, const vec2f& uv3, const vec2f& current_uv);
 
-// Interpolates values over a line parameterized from a to b by u. Same as lerp.
+/// Interpolates values over a line parameterized from a to b by u. Same as lerp.
 template <typename T>
 inline T interpolate_line(const T& p0, const T& p1, float u) {
   return p0 * (1 - u) + p1 * u;
 }
-// Interpolates values over a triangle parameterized by u and v along the
-// (p1-p0) and (p2-p0) directions. Same as barycentric interpolation.
+/// Interpolates values over a triangle parameterized by u and v along the
+/// (p1-p0) and (p2-p0) directions. Same as barycentric interpolation.
 template <typename T>
 inline T interpolate_triangle(
     const T& p0, const T& p1, const T& p2, const vec2f& uv) {
   return p0 * (1 - uv.x - uv.y) + p1 * uv.x + p2 * uv.y;
 }
-// Interpolates values over a quad parameterized by u and v along the
-// (p1-p0) and (p2-p1) directions. Same as bilinear interpolation.
+/// Interpolates values over a quad parameterized by u and v along the
+/// (p1-p0) and (p2-p1) directions. Same as bilinear interpolation.
 template <typename T>
 inline T interpolate_quad(
     const T& p0, const T& p1, const T& p2, const T& p3, const vec2f& uv) {
@@ -721,14 +721,14 @@ inline T interpolate_quad(
 #endif
 }
 
-// Interpolates values along a cubic Bezier segment parametrized by u.
+/// Interpolates values along a cubic Bezier segment parametrized by u.
 template <typename T>
 inline T interpolate_bezier(
     const T& p0, const T& p1, const T& p2, const T& p3, float u) {
   return p0 * (1 - u) * (1 - u) * (1 - u) + p1 * 3 * u * (1 - u) * (1 - u) +
          p2 * 3 * u * u * (1 - u) + p3 * u * u * u;
 }
-// Computes the derivative of a cubic Bezier segment parametrized by u.
+/// Computes the derivative of a cubic Bezier segment parametrized by u.
 template <typename T>
 inline T interpolate_bezier_derivative(
     const T& p0, const T& p1, const T& p2, const T& p3, float u) {
@@ -736,7 +736,7 @@ inline T interpolate_bezier_derivative(
          (p3 - p2) * 3 * u * u;
 }
 
-// Triangle tangent and bitangent from uv
+/// Triangle tangent and bitangent from uv
 inline pair<vec3f, vec3f> triangle_tangents_fromuv(const vec3f& p0,
     const vec3f& p1, const vec3f& p2, const vec2f& uv0, const vec2f& uv1,
     const vec2f& uv2) {
@@ -762,7 +762,7 @@ inline pair<vec3f, vec3f> triangle_tangents_fromuv(const vec3f& p0,
   }
 }
 
-// Quad tangent and bitangent from uv.
+/// Quad tangent and bitangent from uv.
 inline pair<vec3f, vec3f> quad_tangents_fromuv(const vec3f& p0, const vec3f& p1,
     const vec3f& p2, const vec3f& p3, const vec2f& uv0, const vec2f& uv1,
     const vec2f& uv2, const vec2f& uv3, const vec2f& current_uv) {

--- a/yocto/yocto_trace.h
+++ b/yocto/yocto_trace.h
@@ -1,35 +1,35 @@
-//
-// # Yocto/Trace: Tiny path tracer
-//
-//
-// Yocto/Trace is a simple path tracing library with support for microfacet
-// materials, area and environment lights, and advacned sampling.
-//
-//
-// ## Physically-based Path Tracing
-//
-// Yocto/Trace includes a tiny, but fully featured, path tracer with support for
-// textured mesh area lights, GGX materials, environment mapping. The algorithm
-// makes heavy use of MIS for fast convergence.
-// The interface supports progressive parallel execution both synchronously,
-// for CLI applications, and asynchronously for interactive viewing.
-//
-// Materials are represented as sums of an emission term, a diffuse term and
-// a specular microfacet term (GGX or Phong), and a transmission term for
-// this sheet glass.
-// Lights are defined as any shape with a material emission term. Additionally
-// one can also add environment maps. But even if you can, you might want to
-// add a large triangle mesh with inward normals instead. The latter is more
-// general (you can even more an arbitrary shape sun). For now only the first
-// environment is used.
-//
-// 1. prepare the ray-tracing acceleration structure with `build_bvh()`
-// 2. prepare lights for rendering with `init_trace_lights()`
-// 3. create the random number generators with `init_trace_state()`
-// 4. render blocks of samples with `trace_samples()`
-// 5. you can also start an asynchronous renderer with `trace_asynch_start()`
-//
-//
+///
+/// # Yocto/Trace: Tiny path tracer
+///
+///
+/// Yocto/Trace is a simple path tracing library with support for microfacet
+/// materials, area and environment lights, and advacned sampling.
+///
+///
+/// ## Physically-based Path Tracing
+///
+/// Yocto/Trace includes a tiny, but fully featured, path tracer with support for
+/// textured mesh area lights, GGX materials, environment mapping. The algorithm
+/// makes heavy use of MIS for fast convergence.
+/// The interface supports progressive parallel execution both synchronously,
+/// for CLI applications, and asynchronously for interactive viewing.
+///
+/// Materials are represented as sums of an emission term, a diffuse term and
+/// a specular microfacet term (GGX or Phong), and a transmission term for
+/// this sheet glass.
+/// Lights are defined as any shape with a material emission term. Additionally
+/// one can also add environment maps. But even if you can, you might want to
+/// add a large triangle mesh with inward normals instead. The latter is more
+/// general (you can even more an arbitrary shape sun). For now only the first
+/// environment is used.
+///
+/// 1. prepare the ray-tracing acceleration structure with `build_bvh()`
+/// 2. prepare lights for rendering with `init_trace_lights()`
+/// 3. create the random number generators with `init_trace_state()`
+/// 4. render blocks of samples with `trace_samples()`
+/// 5. you can also start an asynchronous renderer with `trace_asynch_start()`
+///
+///
 
 //
 // LICENSE:
@@ -83,10 +83,10 @@
 // -----------------------------------------------------------------------------
 namespace yocto {
 
-// Default trace seed
+/// Default trace seed
 const auto trace_default_seed = 961748941ull;
 
-// Trace lights used during rendering.
+/// Trace lights used during rendering.
 struct trace_lights {
   vector<int>           instances        = {};
   vector<int>           environments     = {};
@@ -96,11 +96,11 @@ struct trace_lights {
   bool empty() const { return instances.empty() && environments.empty(); }
 };
 
-// Initialize lights.
+/// Initialize lights.
 trace_lights make_trace_lights(const yocto_scene& scene);
 void         make_trace_lights(trace_lights& lights, const yocto_scene& scene);
 
-// State of a pixel during tracing
+/// State of a pixel during tracing
 struct trace_pixel {
   vec3f     radiance = zero3f;
   int       hits     = 0;
@@ -112,27 +112,27 @@ struct trace_state {
   vector<trace_pixel> pixels     = {};
 };
 
-// Initialize state of the renderer.
+/// Initialize state of the renderer.
 trace_state make_trace_state(
     const vec2i& image_size, uint64_t random_seed = trace_default_seed);
 void make_trace_state(trace_state& state, const vec2i& image_size,
     uint64_t random_seed = trace_default_seed);
 
-// Options for trace functions
+/// Options for trace functions
 struct trace_params {
-  // clang-format off
-  // Type of tracing algorithm to use
+  /// clang-format off
+  /// Type of tracing algorithm to use
   enum struct sampler_type {
-    path,        // path tracing
-    naive,       // naive path tracing
-    eyelight,    // eyelight rendering
-    falsecolor,  // false color rendering
+    path,        /// path tracing
+    naive,       /// naive path tracing
+    eyelight,    /// eyelight rendering
+    falsecolor,  /// false color rendering
   };
   enum struct falsecolor_type {
     normal, frontfacing, gnormal, gfrontfacing, texcoord, color, emission,    
     diffuse, specular, transmission, roughness, material, shape, instance,    
     highlight };
-  // clang-format on
+  /// clang-format on
 
   int                camera     = 0;
   int                resolution = 1280;
@@ -158,7 +158,7 @@ const auto trace_falsecolor_names = vector<string>{"normal", "frontfacing",
     "specular", "transmission", "roughness", "material", "shape", "instance",
     "highlight"};
 
-// Equality operators
+/// Equality operators
 inline bool operator==(const trace_params& a, const trace_params& b) {
   return memcmp(&a, &b, sizeof(a)) == 0;
 }
@@ -166,29 +166,29 @@ inline bool operator!=(const trace_params& a, const trace_params& b) {
   return memcmp(&a, &b, sizeof(a)) != 0;
 }
 
-// Progressively compute an image by calling trace_samples multiple times.
+/// Progressively compute an image by calling trace_samples multiple times.
 image<vec4f> trace_image(const yocto_scene& scene, const bvh_scene& bvh,
     const trace_lights& lights, const trace_params& params);
 
-// Progressively compute an image by calling trace_samples multiple times.
-// Start with an empty state and then successively call this function to
-// render the next batch of samples.
+/// Progressively compute an image by calling trace_samples multiple times.
+/// Start with an empty state and then successively call this function to
+/// render the next batch of samples.
 int trace_samples(image<vec4f>& image, trace_state& state,
     const yocto_scene& scene, const bvh_scene& bvh, const trace_lights& lights,
     int current_sample, const trace_params& params);
 
-// Progressively compute an image by calling trace_region multiple times.
-// Compared to `trace_samples` this always runs serially and is helpful
-// when building async applications.
+/// Progressively compute an image by calling trace_region multiple times.
+/// Compared to `trace_samples` this always runs serially and is helpful
+/// when building async applications.
 void trace_region(image<vec4f>& image, trace_state& state,
     const yocto_scene& scene, const bvh_scene& bvh, const trace_lights& lights,
     const image_region& region, int num_samples, const trace_params& params);
 
-// Check is a sampler requires lights
+/// Check is a sampler requires lights
 bool is_sampler_lit(const trace_params& params);
 
-// Trace statistics for last run used for fine tuning implementation.
-// For now returns number of paths and number of rays.
+/// Trace statistics for last run used for fine tuning implementation.
+/// For now returns number of paths and number of rays.
 pair<uint64_t, uint64_t> get_trace_stats();
 void                     reset_trace_stats();
 
@@ -199,27 +199,27 @@ void                     reset_trace_stats();
 // -----------------------------------------------------------------------------
 namespace yocto {
 
-// Phong exponent to roughness.
+/// Phong exponent to roughness.
 float exponent_to_roughness(float n);
 
-// Specular to fresnel eta.
+/// Specular to fresnel eta.
 vec3f              reflectivity_to_eta(const vec3f& reflectivity);
 vec3f              eta_to_reflectivity(const vec3f& eta);
 pair<vec3f, vec3f> reflectivity_to_eta(
     const vec3f& reflectivity, const vec3f& edge_tint);
 vec3f eta_to_reflectivity(const vec3f& eta, const vec3f& etak);
 vec3f eta_to_edge_tint(const vec3f& eta, const vec3f& etak);
-// Compute the fresnel term for dielectrics.
+/// Compute the fresnel term for dielectrics.
 vec3f fresnel_dielectric(const vec3f& eta, float direction_cosine);
-// Compute the fresnel term for metals.
+/// Compute the fresnel term for metals.
 vec3f fresnel_conductor(
     const vec3f& eta, const vec3f& etak, float direction_cosine);
-// Schlick approximation of Fresnel term, optionally weighted by roughness;
+/// Schlick approximation of Fresnel term, optionally weighted by roughness;
 vec3f fresnel_schlick(const vec3f& specular, float direction_cosine);
 vec3f fresnel_schlick(
     const vec3f& specular, float direction_cosine, float roughness);
 
-// Evaluates the microfacet distribution and geometric term (ggx or beckman).
+/// Evaluates the microfacet distribution and geometric term (ggx or beckman).
 float eval_microfacetD(float roughness, const vec3f& normal,
     const vec3f& half_vector, bool ggx = true);
 float eval_microfacetG(float roughness, const vec3f& normal,
@@ -230,12 +230,12 @@ vec3f sample_microfacet(
 float sample_microfacet_pdf(float roughness, const vec3f& normal,
     const vec3f& half_vector, bool ggx = true);
 
-// Evaluate and sample volume phase function.
+/// Evaluate and sample volume phase function.
 vec3f sample_phasefunction(float vg, const vec2f& u);
 float eval_phasefunction(float cos_theta, float vg);
 
-// Get complex ior from metal names (eta, etak).
-// Return zeros if not available.
+/// Get complex ior from metal names (eta, etak).
+/// Return zeros if not available.
 pair<vec3f, vec3f> get_conductor_eta(const string& element);
 
 }  // namespace yocto


### PR DESCRIPTION
Changing code comments from `//` to `///` allow automatic code generation.

This allows creating a documented public API in either doxygen or doxiz. 

See https://doxiz.com/yocto-gl

Disclaimer, I'm the creator of https://doxiz.com/

![yocto-gl doxiz](https://user-images.githubusercontent.com/4282254/59680213-78ac4f80-91d9-11e9-9f80-01bfe5da57f0.png)
