### PR TITLE
Fix Linux build

### DIFF
--- a/libs/yocto/CMakeLists.txt
+++ b/libs/yocto/CMakeLists.txt
@@ -29,6 +29,9 @@ if(YOCTO_EMBREE)
     link_directories("/Program Files/Intel/Embree3 X64/lib" "C:/Program Files/Intel/Embree3 X64/lib")
     target_link_libraries(yocto embree3 tbb tbbmalloc)
   endif(MSVC)
+  if(UNIX AND NOT APPLE)
+    target_link_libraries(yocto embree3)
+  endif()
 endif(YOCTO_EMBREE)
 
 # warning flags

--- a/libs/yocto/yocto_shape.cpp
+++ b/libs/yocto/yocto_shape.cpp
@@ -8,6 +8,7 @@
 
 #include "yocto_shape.h"
 
+#include <atomic>
 #include <deque>
 #include <memory>
 #include <string>

--- a/libs/yocto/yocto_shape.h
+++ b/libs/yocto/yocto_shape.h
@@ -122,6 +122,7 @@
 // INCLUDES
 // -----------------------------------------------------------------------------
 
+#include <memory>
 #include <tuple>
 #include <unordered_map>
 

--- a/libs/yocto/yocto_trace.cpp
+++ b/libs/yocto/yocto_trace.cpp
@@ -29,6 +29,7 @@
 #include "yocto_trace.h"
 
 #include <atomic>
+#include <cstring>
 #include <deque>
 #include <future>
 #include <memory>

--- a/libs/yocto_gui/yocto_gui.h
+++ b/libs/yocto_gui/yocto_gui.h
@@ -442,7 +442,7 @@ struct window {
   uiupdate_callback uiupdate_cb   = {};
   int               widgets_width = 0;
   bool              widgets_left  = true;
-  input             input         = {};
+  yocto::gui::input input         = {};
   vec4f             background    = {0.15f, 0.15f, 0.15f, 1.0f};
 };
 


### PR DESCRIPTION
Fixed compilation errors leading to build failure under Linux, with both
GCC and Clang.

Full list of changes:
 - yocto_gui.hpp: the 'input' member shared the name with its
   type, which is not allowed in standard C++17 even though certain
   compilers will allow it. Replacing the type with the fully
   qualified name fixes the error
 - yocto_trace.cpp: Added include cstring that is apparently
   imported as a side effect of other includes on Windows, but not on
   Linux
 - yocto_shape.h: Added include memory, same reason as above
 - yocto_shape.cpp: Added include atomic, same reason as above
 - Modified CMakeLists to link embree3 when compiling under Linux with
   YOCTO_EMBREE defined