### PR TITLE
Fix linux build

### DIFF
--- a/exts/embree/CMakeLists.txt
+++ b/exts/embree/CMakeLists.txt
@@ -25,7 +25,7 @@ if(MSVC)
 endif(MSVC)
 if(UNIX AND NOT APPLE)
   target_include_directories(embree INTERFACE /usr/local/include)
-  set_target_properties(embree PROPERTY
+  set_target_properties(embree PROPERTIES
     IMPORTED_LINK_INTERFACE_LANGUAGES "CXX"
     IMPORTED_LOCATION "/usr/local/lib/libembree3.so"
     INTERFACE_INCLUDE_DIRECTORIES "/usr/local/include")

--- a/exts/openimagedenoise/CMakeLists.txt
+++ b/exts/openimagedenoise/CMakeLists.txt
@@ -25,7 +25,7 @@ if(MSVC)
 endif(MSVC)
 if(UNIX AND NOT APPLE)
   target_include_directories(openimagedenoise INTERFACE /usr/local/include)
-  set_target_properties(openimagedenoise PROPERTY
+  set_target_properties(openimagedenoise PROPERTIES
     IMPORTED_LINK_INTERFACE_LANGUAGES "CXX"
     IMPORTED_LOCATION "/usr/local/lib/libOpenImageDenoise.so"
     INTERFACE_INCLUDE_DIRECTORIES "/usr/local/include")

--- a/libs/yocto/yocto_sceneio.cpp
+++ b/libs/yocto/yocto_sceneio.cpp
@@ -46,6 +46,7 @@
 #include <memory>
 #include <nlohmann/json.hpp>
 #include <stdexcept>
+#include <thread>
 #include <unordered_map>
 
 #include "yocto_color.h"


### PR DESCRIPTION
Fixed cmake typos.
Fixed #1396.
Tested with gcc and clang.