### PR TITLE
Fix build under fedora 38

### DIFF
--- a/libs/yocto/yocto_modelio.h
+++ b/libs/yocto/yocto_modelio.h
@@ -38,6 +38,8 @@
 // INCLUDES
 // -----------------------------------------------------------------------------
 
+#include <stdint.h>
+
 #include <algorithm>
 #include <array>
 #include <stdexcept>


### PR DESCRIPTION
Include `stdio.h` in `yocto_modelio.h` that is probably being included transitively on other platforms.
This fixes compilation on Fedora 38 and probably on other distros using modern versions of gcc.